### PR TITLE
Skip the package/deploy steps. This will be handled by internal CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,27 +109,27 @@ workflows:
           filters:
             branches:
               ignore: gh-pages          
-      - package:
-          requires:
-            - build
-          context: itpro
-      - deploy_to_test:
-          requires:
-            - package
-          context: itpro
+#      - package:
+#          requires:
+#            - build
+#          context: itpro
+#      - deploy_to_test:
+#          requires:
+#            - package
+#          context: itpro
 #      - migrate_test_db:
 #          requires:
 #            - deploy_to_test
 #          context: azfun-fsharp
-      - deploy_to_production:
-          filters:
-            branches:
-              only:
-                - master
-          requires:
-            - package
-          context: itpro
-      - migrate_production_db:
-          requires:
-            - deploy_to_production
-          context: itpro
+#      - deploy_to_production:
+#          filters:
+#            branches:
+#              only:
+#                - master
+#          requires:
+#            - package
+#          context: itpro
+#      - migrate_production_db:
+#          requires:
+#            - deploy_to_production
+#          context: itpro


### PR DESCRIPTION
Circle CI can't support the database migration because we can't create a SQL Server firewall rule for the Circle VM IP space (basically all of AWS East.) So we'll do the deploy and migrate stuff from an internal CI server, but still do the build/test on public CI.