### PR TITLE
Normalize branch name for Docker tag

### DIFF
--- a/.teamcity/docker-build-tag-push.sh
+++ b/.teamcity/docker-build-tag-push.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Source the tag name
-source docker-tag-name.sh
+# Export the tag name
+export DOCKER_TAG=${TEAMCITY_BRANCH/\/refs\/heads\//}
 
 # Build the docker image and tag it for docker hub
 docker build -t functions .

--- a/.teamcity/docker-build-tag-push.sh
+++ b/.teamcity/docker-build-tag-push.sh
@@ -1,15 +1,18 @@
 #!/bin/bash
 
+# Resolve the current branch name
+resolved_branch = ${TEAMCITY_BRANCH/\/refs\/heads\//}
+
 # Build the docker image and tag it for docker hub
 docker build -t functions .
 
 # Tag image for docker hub
-echo Tagging functions image as $DOCKER_HUB_REPO:$TEAMCITY_BRANCH
-docker tag functions $DOCKER_HUB_REPO:$TEAMCITY_BRANCH
+echo Tagging functions image as $DOCKER_HUB_REPO:$resolved_branch
+docker tag functions $DOCKER_HUB_REPO:$resolved_branch
 
 # Login to Docker Hub
 printf $DOCKER_HUB_PASSWORD | docker login --username $DOCKER_HUB_USERNAME --password-stdin
 
 # Push the image to Docker Hub
-echo Pushing $DOCKER_HUB_REPO:$TEAMCITY_BRANCH to Docker Hub
-docker push $DOCKER_HUB_REPO:$TEAMCITY_BRANCH
+echo Pushing $DOCKER_HUB_REPO:$resolved_branch to Docker Hub
+docker push $DOCKER_HUB_REPO:$resolved_branch

--- a/.teamcity/docker-build-tag-push.sh
+++ b/.teamcity/docker-build-tag-push.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
 # Resolve the current branch name
-resolved_branch = ${TEAMCITY_BRANCH/\/refs\/heads\//}
+export RESOLVED_BRANCH=${TEAMCITY_BRANCH/\/refs\/heads\//}
 
 # Build the docker image and tag it for docker hub
 docker build -t functions .
 
 # Tag image for docker hub
-echo Tagging functions image as $DOCKER_HUB_REPO:$resolved_branch
-docker tag functions $DOCKER_HUB_REPO:$resolved_branch
+echo Tagging functions image as $DOCKER_HUB_REPO:$RESOLVED_BRANCH
+docker tag functions $DOCKER_HUB_REPO:$RESOLVED_BRANCH
 
 # Login to Docker Hub
 printf $DOCKER_HUB_PASSWORD | docker login --username $DOCKER_HUB_USERNAME --password-stdin
 
 # Push the image to Docker Hub
-echo Pushing $DOCKER_HUB_REPO:$resolved_branch to Docker Hub
-docker push $DOCKER_HUB_REPO:$resolved_branch
+echo Pushing $DOCKER_HUB_REPO:$RESOLVED_BRANCH to Docker Hub
+docker push $DOCKER_HUB_REPO:$RESOLVED_BRANCH

--- a/.teamcity/docker-build-tag-push.sh
+++ b/.teamcity/docker-build-tag-push.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
-# Resolve the current branch name
-export RESOLVED_BRANCH=${TEAMCITY_BRANCH/\/refs\/heads\//}
+# Source the tag name
+source docker-tag-name.sh
 
 # Build the docker image and tag it for docker hub
 docker build -t functions .
 
 # Tag image for docker hub
-echo Tagging functions image as $DOCKER_HUB_REPO:$RESOLVED_BRANCH
-docker tag functions $DOCKER_HUB_REPO:$RESOLVED_BRANCH
+echo Tagging functions image as $DOCKER_HUB_REPO:$DOCKER_TAG
+docker tag functions $DOCKER_HUB_REPO:$DOCKER_TAG
 
 # Login to Docker Hub
 printf $DOCKER_HUB_PASSWORD | docker login --username $DOCKER_HUB_USERNAME --password-stdin
 
 # Push the image to Docker Hub
-echo Pushing $DOCKER_HUB_REPO:$RESOLVED_BRANCH to Docker Hub
-docker push $DOCKER_HUB_REPO:$RESOLVED_BRANCH
+echo Pushing $DOCKER_HUB_REPO:$DOCKER_TAG to Docker Hub
+docker push $DOCKER_HUB_REPO:$DOCKER_TAG

--- a/.teamcity/docker-service-update.sh
+++ b/.teamcity/docker-service-update.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 
-# Resolve the current branch name by stripping any leading '/refs/heads/'
-resolved_branch = ${TEAMCITY_BRANCH/\/refs\/heads\//}
-
 # Source the Docker client bundle for the environment associated with this build.
 source $HOME/.dcd/$DOCKER_UCP_BUNDLE.sh
 
 # Update the service and non-secret environment variables
-docker service update --image $DOCKER_HUB_REPO:$resolved_branch \
+docker service update --image $DOCKER_HUB_REPO:$RESOLVED_BRANCH \
     --health-cmd 'curl --fail localhost:80/api/ping || exit 1' \
     --health-interval 1s \
     --health-retries 120 \

--- a/.teamcity/docker-service-update.sh
+++ b/.teamcity/docker-service-update.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
+# Resolve the current branch name by stripping any leading '/refs/heads/'
+resolved_branch = ${TEAMCITY_BRANCH/\/refs\/heads\//}
+
 # Source the Docker client bundle for the environment associated with this build.
 source $HOME/.dcd/$DOCKER_UCP_BUNDLE.sh
 
 # Update the service and non-secret environment variables
-docker service update --image $DOCKER_HUB_REPO:$TEAMCITY_BRANCH \
+docker service update --image $DOCKER_HUB_REPO:$resolved_branch \
     --health-cmd 'curl --fail localhost:80/api/ping || exit 1' \
     --health-interval 1s \
     --health-retries 120 \

--- a/.teamcity/docker-service-update.sh
+++ b/.teamcity/docker-service-update.sh
@@ -7,9 +7,10 @@ export DOCKER_TAG=${TEAMCITY_BRANCH/\/refs\/heads\//}
 source $HOME/.dcd/$DOCKER_UCP_BUNDLE.sh
 
 # Update the service and non-secret environment variables
+echo Updating itpeople-functions service from $DOCKER_HUB_REPO:$DOCKER_TAG
 docker service update --image $DOCKER_HUB_REPO:$DOCKER_TAG \
     --health-cmd 'curl --fail localhost:80/api/ping || exit 1' \
-    --health-interval 1s \
+    --health-interval 2s \
     --health-retries 120 \
     --health-start-period 10s \
     --health-timeout 5s \

--- a/.teamcity/docker-service-update.sh
+++ b/.teamcity/docker-service-update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Source the tag name
-source docker-tag-name.sh
+source .teamcity/docker-tag-name.sh
 
 # Source the Docker client bundle for the environment associated with this build.
 source $HOME/.dcd/$DOCKER_UCP_BUNDLE.sh

--- a/.teamcity/docker-service-update.sh
+++ b/.teamcity/docker-service-update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Source the tag name
-source .teamcity/docker-tag-name.sh
+# Export the tag name
+export DOCKER_TAG=${TEAMCITY_BRANCH/\/refs\/heads\//}
 
 # Source the Docker client bundle for the environment associated with this build.
 source $HOME/.dcd/$DOCKER_UCP_BUNDLE.sh

--- a/.teamcity/docker-service-update.sh
+++ b/.teamcity/docker-service-update.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
+# Source the tag name
+source docker-tag-name.sh
+
 # Source the Docker client bundle for the environment associated with this build.
 source $HOME/.dcd/$DOCKER_UCP_BUNDLE.sh
 
 # Update the service and non-secret environment variables
-docker service update --image $DOCKER_HUB_REPO:$RESOLVED_BRANCH \
+docker service update --image $DOCKER_HUB_REPO:$DOCKER_TAG \
     --health-cmd 'curl --fail localhost:80/api/ping || exit 1' \
     --health-interval 1s \
     --health-retries 120 \

--- a/.teamcity/docker-tag-name.sh
+++ b/.teamcity/docker-tag-name.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# Resolve the tag as the current branch name
-export DOCKER_TAG=${TEAMCITY_BRANCH/\/refs\/heads\//}

--- a/.teamcity/docker-tag-name.sh
+++ b/.teamcity/docker-tag-name.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Resolve the tag as the current branch name
+export DOCKER_TAG=${TEAMCITY_BRANCH/\/refs\/heads\//}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM microsoft/dotnet:2.1-sdk AS installer-env
 COPY . /src/dotnet-function-app
 RUN cd /src/dotnet-function-app && \
     mkdir -p /home/site/wwwroot && \
-    dotnet publish -c Release functions/azfun.fsproj --output /home/site/wwwroot
+    dotnet publish -c Release functions/functions.fsproj --output /home/site/wwwroot
 
 FROM microsoft/azure-functions-dotnet-core2.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot


### PR DESCRIPTION
TeamCity is a little goofy sometimes. It can set the $TEAMCITY_BRANCH as `/refs/heads/develop` or `some-feature`, depending on whether the current branch is also the base branch. This is a problem because Docker tags can't contain slashes. As a workaround this PR normalizes the branch names as:
* `/refs/heads/develop` -> `develop`
* `some-feature` -> `some-feature`
