### PR TITLE
Address Containerization issues

### DIFF
--- a/docker-start.sh
+++ b/docker-start.sh
@@ -8,7 +8,7 @@ docker rm funcs
 docker build -t funcs .
 #docker tag funcs uitsssl/itpeople-functions:sandbox
 #docker tag funcs registry-test.docker.iu.edu/repositories/dcd/itpeople-functions:sandbox
-docker run -p 9090:80 -d --name funcs funcs
+docker run -p 7071:80 -d --name funcs funcs
 
 # open browser
-open http://localhost:9090/api/ping
+open http://localhost:7071/ping

--- a/functions.tests.integration/ContractTests.fs
+++ b/functions.tests.integration/ContractTests.fs
@@ -41,6 +41,8 @@ module ContractTests =
             let mutable stateServer = None
 
             try            
+                Environment.SetEnvironmentVariable("CorsHosts","*")
+                Environment.SetEnvironmentVariable("UseFakeData","false")
                 Environment.SetEnvironmentVariable("JwtSecret","jwt signing secret")
                 Environment.SetEnvironmentVariable("DbConnectionString","User ID=root;Host=localhost;Port=5432;Database=circle_test;Pooling=true;")
 

--- a/functions.tests.stateserver/Functions.fs
+++ b/functions.tests.stateserver/Functions.fs
@@ -71,17 +71,17 @@ module Functions =
     [<FunctionName("InitializeState")>]
     let initializeState
         ([<HttpTrigger(Extensions.Http.AuthorizationLevel.Anonymous, "post", Route = "state")>]
-        req: HttpRequestMessage) =
+        req: HttpRequestMessage, context: ExecutionContext) =
         let connStr = System.Environment.GetEnvironmentVariable("DbConnectionString")
         let fn () = ensureState req connStr
-        getResponse' req log fn
+        getResponse' req log context fn
 
     
     /// (Anonymous) A function that simply returns, "Pong!" 
     [<FunctionName("PingGet")>]
     let ping
         ([<HttpTrigger(Extensions.Http.AuthorizationLevel.Anonymous, "get", Route = "ping")>]
-        req: HttpRequestMessage) =
+        req: HttpRequestMessage, context: ExecutionContext) =
         let fn () = Functions.Api.Ping.get req
         // let fn () = Api.Ping.get req
-        getResponse' req log fn
+        getResponse' req log context fn

--- a/functions.tests.unit/TestFakes.fs
+++ b/functions.tests.unit/TestFakes.fs
@@ -33,4 +33,5 @@ module TestFakes =
         JwtSecret=jwtSingingSecret
         DbConnectionString="db connectionString"
         UseFakes=false
+        CorsHosts="*"
     }

--- a/functions.tests.unit/TestFakes.fs
+++ b/functions.tests.unit/TestFakes.fs
@@ -32,4 +32,5 @@ module TestFakes =
         OAuth2RedirectUrl="redirect url"
         JwtSecret=jwtSingingSecret
         DbConnectionString="db connectionString"
+        UseFakes=false
     }

--- a/functions/Api/Auth.fs
+++ b/functions/Api/Auth.fs
@@ -46,7 +46,7 @@ module Auth =
     /// containing the original JWT, the user ID, and user Role.  
     let get (req: HttpRequestMessage) config (queryUserByName:string -> AsyncResult<User,Error>) = asyncTrial {
         let getUaaJwt request = bindAsyncResult (fun () -> postAsync<ResponseModel> config.OAuth2TokenUrl request)
-        let! oauthCode = getQueryParam "code" req
+        let! oauthCode = getQueryParam "oauth_code" req
         let! uaaRequest = createTokenRequest config.OAuth2ClientId config.OAuth2ClientSecret config.OAuth2RedirectUrl oauthCode
         let! uaaJwt = getUaaJwt uaaRequest
         let! uaaClaims = decodeUaaJwt uaaJwt.access_token

--- a/functions/Api/Auth.fs
+++ b/functions/Api/Auth.fs
@@ -50,8 +50,8 @@ module Auth =
         let! uaaRequest = createTokenRequest config.OAuth2ClientId config.OAuth2ClientSecret config.OAuth2RedirectUrl oauthCode
         let! uaaJwt = getUaaJwt uaaRequest
         let! uaaClaims = decodeUaaJwt uaaJwt.access_token
-        let! user = queryUserByName uaaClaims.UserName
-        let! appJwt = encodeJwt config.JwtSecret uaaClaims.Expiration user.Id user.NetId
+        // let! user = queryUserByName uaaClaims.UserName
+        let! appJwt = encodeJwt config.JwtSecret uaaClaims.Expiration uaaClaims.UserId uaaClaims.UserName
         let result = { access_token = appJwt }          
         return result
     }

--- a/functions/Api/Auth.fs
+++ b/functions/Api/Auth.fs
@@ -50,8 +50,8 @@ module Auth =
         let! uaaRequest = createTokenRequest config.OAuth2ClientId config.OAuth2ClientSecret config.OAuth2RedirectUrl oauthCode
         let! uaaJwt = getUaaJwt uaaRequest
         let! uaaClaims = decodeUaaJwt uaaJwt.access_token
-        // let! user = queryUserByName uaaClaims.UserName
-        let! appJwt = encodeJwt config.JwtSecret uaaClaims.Expiration uaaClaims.UserId uaaClaims.UserName
+        let! user = queryUserByName uaaClaims.UserName
+        let! appJwt = encodeJwt config.JwtSecret uaaClaims.Expiration user.Id user.NetId
         let result = { access_token = appJwt }          
         return result
     }

--- a/functions/Api/Common.fs
+++ b/functions/Api/Common.fs
@@ -85,8 +85,6 @@ module Common =
             let origin = origin req
             let response = new HttpResponseMessage(Status.OK)
             addCORSHeader response origin config.CorsHosts
-            log.Information(sprintf "  Referrer: %s" origin)
-            log.Information(sprintf "  Allowed CORS Hosts: %s" config.CorsHosts)
             response
 
     /// <summary>

--- a/functions/Api/Common.fs
+++ b/functions/Api/Common.fs
@@ -85,6 +85,9 @@ module Common =
             let referrer = referrer req.RequestUri
             let response = new HttpResponseMessage(Status.OK)
             addCORSHeader response referrer config.CorsHosts
+            log.Information(sprintf "  Referrer: %s" referrer)
+            log.Information(sprintf "  Allowed CORS Hosts: %s" config.CorsHosts)
+            log.Information(sprintf "  Response Headers: %s" (response.Headers.ToString()))
             response
 
     /// <summary>

--- a/functions/Api/Common.fs
+++ b/functions/Api/Common.fs
@@ -19,7 +19,7 @@ module Common =
     let private getDependencies(context: ExecutionContext) : AppConfig*IDataRepository = 
         let configRoot = 
             ConfigurationBuilder()
-                .AddJsonFile("local.settings.json", optional=true, reloadOnChange=true)
+                .AddJsonFile("local.settings.json", optional=true)
                 .AddKeyPerFile("/run/secrets", optional=true)
                 .AddEnvironmentVariables()
                 .Build();

--- a/functions/Api/Common.fs
+++ b/functions/Api/Common.fs
@@ -31,10 +31,14 @@ module Common =
             OAuth2RedirectUrl = configRoot.["OAuthRedirectUrl"]
             JwtSecret = configRoot.["JwtSecret"]
             DbConnectionString = configRoot.["DbConnectionString"]
+            UseFakes = bool.Parse configRoot.["UseFakeData"]
         }
 
-        let data = DatabaseRepository(appConfig.DbConnectionString) :> IDataRepository
-        // let data = FakesRepository() :> IDataRepository
+        let data = 
+            if appConfig.UseFakes
+            then FakesRepository() :> IDataRepository
+            else DatabaseRepository(appConfig.DbConnectionString) :> IDataRepository
+
         (appConfig,data)
 
     /// Given an API function, resolve required dependencies and get a response.  

--- a/functions/Api/Common.fs
+++ b/functions/Api/Common.fs
@@ -76,6 +76,17 @@ module Common =
                 return constructResponse req log "" (fail(Status.InternalServerError, msg))
         } |> Async.StartAsTask
 
+    /// Given an API function, get a response.  
+    let optionsResponse
+        (req: HttpRequestMessage)
+        (log: Logger) 
+        (context: ExecutionContext)  = 
+            let (config,data) = getDependencies(context)
+            let referrer = referrer req.RequestUri
+            let response = new HttpResponseMessage(Status.OK)
+            addCORSHeader response referrer config.CorsHosts
+            response
+
     /// <summary>
     /// Get all items.
     /// </summary>

--- a/functions/Api/Common.fs
+++ b/functions/Api/Common.fs
@@ -82,12 +82,11 @@ module Common =
         (log: Logger) 
         (context: ExecutionContext)  = 
             let (config,data) = getDependencies(context)
-            let referrer = referrer req.RequestUri
+            let origin = origin req
             let response = new HttpResponseMessage(Status.OK)
-            addCORSHeader response referrer config.CorsHosts
-            log.Information(sprintf "  Referrer: %s" referrer)
+            addCORSHeader response origin config.CorsHosts
+            log.Information(sprintf "  Referrer: %s" origin)
             log.Information(sprintf "  Allowed CORS Hosts: %s" config.CorsHosts)
-            log.Information(sprintf "  Response Headers: %s" (response.Headers.ToString()))
             response
 
     /// <summary>

--- a/functions/Common/Fakes.fs
+++ b/functions/Common/Fakes.fs
@@ -5,17 +5,17 @@ open Chessie.ErrorHandling
 
 module Fakes =
 
-    let ulrik = {
+    let ronswanson = {
         Id=1
         Hash=""
-        NetId="ulrik"
-        Name="Knudsen, Ulrik Palle"
-        Position="Chief Technology Officer"
+        NetId="rswanso"
+        Name="Swanson, Ron"
+        Position="Parks and Rec Director "
         Location="SMR Room 024"
         Campus="IUBLA"
         CampusPhone="812-856-0207"
-        CampusEmail="ulrik@iu.edu"
-        Expertise="Life, the universe, everything"
+        CampusEmail="rswanso@iu.edu"
+        Expertise="Woodworking, honor"
         Notes="foo"
         Role=Role.Admin
         Tools = Tools.IUware
@@ -51,13 +51,13 @@ module Fakes =
     let itproMail = {Id=2; Name="IT Pro Mailing List"; Description=""}
 
     let getFakeUser () = asyncTrial {
-        let! user = async.Return ulrik
+        let! user = async.Return ronswanson
         return user
     }
 
     let getFakeProfile () : AsyncResult<UserProfile,Error> = asyncTrial {
         let! profile = async.Return {
-            User=ulrik;
+            User=ronswanson;
             Department=arsd;
             UnitMemberships = 
               [ {MemberWithRole.Id=cito.Id; Name=cito.Name; Role=Role.Admin}
@@ -68,7 +68,7 @@ module Fakes =
 
     let getFakeSimpleSearchByTerm () : AsyncResult<SimpleSearch,Error> = asyncTrial {
         let result = {
-                Users=[ulrik; brent]
+                Users=[ronswanson; brent]
                 Departments=[arsd; dema]
                 Units=[cito; clientServices]
             }
@@ -103,7 +103,7 @@ module Fakes =
             Units=[clientServices]
             Members= 
               [ {Member.Id=brent.Id; Name=brent.Name; Description=""}
-                {Member.Id=ulrik.Id; Name=ulrik.Name; Description=""} ]
+                {Member.Id=ronswanson.Id; Name=ronswanson.Name; Description=""} ]
         }
         return profile
     }

--- a/functions/Common/Http.fs
+++ b/functions/Common/Http.fs
@@ -53,7 +53,7 @@ module Http =
     let jsonSettings = JsonSerializerSettings(ContractResolver=CamelCasePropertyNamesContractResolver())
     jsonSettings.Converters.Add(Newtonsoft.Json.Converters.StringEnumConverter())
 
-    let resolveCORSHeader (res:HttpResponseMessage) (referrer:string) (corsHosts:string) =
+    let addCORSHeader (res:HttpResponseMessage) (referrer:string) (corsHosts:string) =
         match corsHosts with
         | null -> ()
         | "" -> ()
@@ -71,7 +71,7 @@ module Http =
         let response = new HttpResponseMessage(status)
         response.Content <- content
         response.Content.Headers.ContentType <- "application/json" |> MediaTypeHeaderValue;
-        resolveCORSHeader response reqHost corsHosts
+        addCORSHeader response reqHost corsHosts
         response
 
     let referrer (uri:System.Uri) = 

--- a/functions/Common/Http.fs
+++ b/functions/Common/Http.fs
@@ -62,7 +62,7 @@ module Http =
             if corsHosts.Split(',') |> Seq.exists (fun c -> c = origin)
             then 
                 res.Headers.Add("Access-Control-Allow-Origin", value=origin)
-                res.Headers.Add("Access-Control-Allow-Headers", "origin, content-type, accept")
+                res.Headers.Add("Access-Control-Allow-Headers", "origin, content-type, accept, authorization")
                 res.Headers.Add("Access-Control-Allow-Credentials", "true")
             else ()
 

--- a/functions/Common/Http.fs
+++ b/functions/Common/Http.fs
@@ -60,7 +60,10 @@ module Http =
         | "*" -> res.Headers.Add("Access-Control-Allow-Origin", "*")
         | _ ->
             if corsHosts.Split(',') |> Seq.exists (fun c -> c = origin)
-            then res.Headers.Add("Access-Control-Allow-Origin", value=origin)
+            then 
+                res.Headers.Add("Access-Control-Allow-Origin", value=origin)
+                res.Headers.Add("Access-Control-Allow-Headers", "origin, content-type, accept")
+                res.Headers.Add("Access-Control-Allow-Credentials", "true")
             else ()
 
     /// Construct an HTTP response with JSON content

--- a/functions/Common/Http.fs
+++ b/functions/Common/Http.fs
@@ -74,8 +74,10 @@ module Http =
         addCORSHeader response reqHost corsHosts
         response
 
-    let origin (req:HttpRequestMessage) = 
-        req.Headers.GetValues("origin") |> Seq.head
+    let origin (req:HttpRequestMessage) =
+        if req.Headers.Contains("origin")
+        then req.Headers.GetValues("origin") |> Seq.head
+        else ""
 
     /// Organize the errors into a status code and a collection of error messages. 
     /// If multiple errors are found, the aggregate status will be that of the 

--- a/functions/Common/Types.fs
+++ b/functions/Common/Types.fs
@@ -27,6 +27,7 @@ module Types =
         JwtSecret: string
         DbConnectionString: string
         UseFakes: bool
+        CorsHosts: string
     }
 
     type Role =

--- a/functions/Common/Types.fs
+++ b/functions/Common/Types.fs
@@ -26,6 +26,7 @@ module Types =
         OAuth2RedirectUrl: string
         JwtSecret: string
         DbConnectionString: string
+        UseFakes: bool
     }
 
     type Role =

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -19,6 +19,12 @@ module Functions =
             .CreateLogger()
 
     /// (Anonymous) A function that simply returns, "Pong!" 
+    [<FunctionName("Options")>]
+    let options
+        ([<HttpTrigger(Extensions.Http.AuthorizationLevel.Anonymous, "options", Route = "{*url}")>]
+        req: HttpRequestMessage, context: ExecutionContext) =
+        Api.Common.optionsResponse req log context
+
     [<FunctionName("PingGet")>]
     let ping
         ([<HttpTrigger(Extensions.Http.AuthorizationLevel.Anonymous, "get", Route = "ping")>]

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -34,27 +34,6 @@ module Functions =
         let fn (config, data:IDataRepository) = Api.Auth.get req config data.GetUserByNetId
         Api.Common.getResponse req log context fn
 
-    /// (Anonymous) Exchanges a UAA OAuth code for an application-scoped JWT
-    [<FunctionName("AuthGetOk")>]
-    let authok
-        ([<HttpTrigger(Extensions.Http.AuthorizationLevel.Anonymous, "get", Route = "authok")>]
-        req: HttpRequestMessage, context: ExecutionContext) =
-        log.Information("authok")
-        new HttpResponseMessage(Status.OK, Content=new StringContent("OK!"))
-
-    [<FunctionName("AuthGetFail")>]
-    let authfail
-        ([<HttpTrigger(Extensions.Http.AuthorizationLevel.Anonymous, "get", Route = "authfail")>]
-        req: HttpRequestMessage, context: ExecutionContext) =
-        log.Error("authfail")
-        new HttpResponseMessage(Status.InternalServerError, Content=new StringContent("Fail!"))
-
-    [<FunctionName("AuthGetFailNoLog")>]
-    let authfailnolog
-        ([<HttpTrigger(Extensions.Http.AuthorizationLevel.Anonymous, "get", Route = "authfailnolog")>]
-        req: HttpRequestMessage, context: ExecutionContext) =
-        new HttpResponseMessage(Status.InternalServerError, Content=new StringContent("Fail No Log!"))
-
     /// (Authenticated) Get a user profile for a given user 'id'
     [<FunctionName("UserGetId")>]
     let profileGet

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -22,9 +22,9 @@ module Functions =
     [<FunctionName("PingGet")>]
     let ping
         ([<HttpTrigger(Extensions.Http.AuthorizationLevel.Anonymous, "get", Route = "ping")>]
-        req: HttpRequestMessage) =
+        req: HttpRequestMessage, context: ExecutionContext) =
         let fn () = Api.Ping.get req
-        Api.Common.getResponse' req log fn
+        Api.Common.getResponse' req log context fn
 
     /// (Anonymous) Exchanges a UAA OAuth code for an application-scoped JWT
     [<FunctionName("AuthGet")>]

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -31,14 +31,9 @@ module Functions =
     let auth
         ([<HttpTrigger(Extensions.Http.AuthorizationLevel.Anonymous, "get", Route = "auth")>]
         req: HttpRequestMessage, context: ExecutionContext) =
-        try
-            let fn (config, data:IDataRepository) = Api.Auth.get req config data.GetUserByNetId
-            Api.Common.getResponse req log context fn |> Async.AwaitTask |> Async.RunSynchronously
-        with
-        | exn -> 
-            log.Error(exn, "[Auth] Something puked....")
-            new HttpResponseMessage(Status.InternalServerError, Content=new StringContent(exn.ToString()))
-
+        let fn (config, data:IDataRepository) = Api.Auth.get req config data.GetUserByNetId
+        Api.Common.getResponse req log context fn
+        
     /// (Authenticated) Get a user profile for a given user 'id'
     [<FunctionName("UserGetId")>]
     let profileGet

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -33,7 +33,28 @@ module Functions =
         req: HttpRequestMessage, context: ExecutionContext) =
         let fn (config, data:IDataRepository) = Api.Auth.get req config data.GetUserByNetId
         Api.Common.getResponse req log context fn
-        
+
+    /// (Anonymous) Exchanges a UAA OAuth code for an application-scoped JWT
+    [<FunctionName("AuthGetOk")>]
+    let authok
+        ([<HttpTrigger(Extensions.Http.AuthorizationLevel.Anonymous, "get", Route = "authok")>]
+        req: HttpRequestMessage, context: ExecutionContext) =
+        log.Information("authok")
+        new HttpResponseMessage(Status.OK, Content=new StringContent("OK!"))
+
+    [<FunctionName("AuthGetFail")>]
+    let authfail
+        ([<HttpTrigger(Extensions.Http.AuthorizationLevel.Anonymous, "get", Route = "authfail")>]
+        req: HttpRequestMessage, context: ExecutionContext) =
+        log.Error("authfail")
+        new HttpResponseMessage(Status.InternalServerError, Content=new StringContent("Fail!"))
+
+    [<FunctionName("AuthGetFailNoLog")>]
+    let authfailnolog
+        ([<HttpTrigger(Extensions.Http.AuthorizationLevel.Anonymous, "get", Route = "authfailnolog")>]
+        req: HttpRequestMessage, context: ExecutionContext) =
+        new HttpResponseMessage(Status.InternalServerError, Content=new StringContent("Fail No Log!"))
+
     /// (Authenticated) Get a user profile for a given user 'id'
     [<FunctionName("UserGetId")>]
     let profileGet

--- a/migrations/Program.fs
+++ b/migrations/Program.fs
@@ -18,9 +18,11 @@ module Program =
             use db = new NpgsqlConnection(connection)
             let runner = db |> migrator |> ConsoleRunner
             args |> List.toArray |> runner.Run
+            0
         with
         | exn -> 
             printf "Error: %s" exn.Message
+            1
 
     /// Clear the database and migrate it to the latest schema
     let clearAndMigrate connection = 
@@ -30,17 +32,18 @@ module Program =
         migrator.MigrateTo(int64 0)
         migrator.MigrateToLatest()
 
+    let usage () =             
+        printf """Usage : dotnet database.dll '<conn>' <args>
+
+  <conn>: the Postgres database connection string
+  <args>: SimpleMigration args (try 'help')"""
+
+
     [<EntryPoint>]
     let main argv =
-
         match argv |> List.ofSeq with
         | connection :: args->
             migrate connection args
         | _ ->
-            printf """Usage : dotnet database.dll '<conn>' <args>
-
-    <conn>: the Postgres database connection string
-    <args>: SimpleMigration args (try 'help')
-    """
-
-        0
+            usage()
+            1


### PR DESCRIPTION
+ Add CORS. The `CorsHosts` config option allows one to specify which origins should be permitted to make requests of the api. Default: none. Can be any of: none, all (`"*"`), a single host (`"http://host.com"`), or multiple hosts (`"http://host1.com,http://host2.com"`)
+ Add `UseFakeData` config option to toggle real (db) or fake (canned). The later might be useful for client testing. We may remove this eventually.
+ Change the `/auth?code=1234` query string to `/auth?oauth_code=1234` since the `code` query param is used internally by the functions host.
+ Add unhandled exception handlers and logging.