### PR TITLE
Add copyright banner to all .fs files

### DIFF
--- a/add-copyright.sh
+++ b/add-copyright.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+for i in $(find . -name '*.fs')  # or whatever file extensions...
+do
+  if ! grep -q Copyright $i
+  then
+    cat copyright.txt $i >$i.new && mv $i.new $i
+  fi
+done

--- a/copyright.txt
+++ b/copyright.txt
@@ -1,0 +1,3 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+

--- a/functions.tests.integration/ContractTests.fs
+++ b/functions.tests.integration/ContractTests.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace Integration
 
 module ContractTests =

--- a/functions.tests.integration/DatabaseTests.fs
+++ b/functions.tests.integration/DatabaseTests.fs
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-﻿namespace Integration 
+namespace Integration 
 
 module DatabaseTests=
 

--- a/functions.tests.integration/DatabaseTests.fs
+++ b/functions.tests.integration/DatabaseTests.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 ﻿namespace Integration 
 
 module DatabaseTests=

--- a/functions.tests.integration/PostgresContainer.fs
+++ b/functions.tests.integration/PostgresContainer.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace Integration 
 
 module PostgresContainer =

--- a/functions.tests.integration/TestFixture.fs
+++ b/functions.tests.integration/TestFixture.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace Integration 
 
 module TestFixture =

--- a/functions.tests.integration/TestHost.fs
+++ b/functions.tests.integration/TestHost.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace Integration
 
 module TestHost =

--- a/functions.tests.unit/FnUserTests.fs
+++ b/functions.tests.unit/FnUserTests.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace Tests
 
 open Chessie.ErrorHandling

--- a/functions.tests.unit/JwtUtilTests.fs
+++ b/functions.tests.unit/JwtUtilTests.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace Tests
 
 open Chessie.ErrorHandling

--- a/functions.tests.unit/Program.fs
+++ b/functions.tests.unit/Program.fs
@@ -1,1 +1,4 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 module Program = let [<EntryPoint>] main _ = 0

--- a/functions.tests.unit/TestFakes.fs
+++ b/functions.tests.unit/TestFakes.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace Tests
 
 open Chessie.ErrorHandling

--- a/functions/Api.fs
+++ b/functions/Api.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace Functions
 
 open Types

--- a/functions/Database.fs
+++ b/functions/Database.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace Functions
 
 open Types

--- a/functions/Fakes.fs
+++ b/functions/Fakes.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace Functions
 
 open Types

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace Functions
 
 open Types

--- a/functions/Http.fs
+++ b/functions/Http.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace Functions
 
 module Http =

--- a/functions/Json.fs
+++ b/functions/Json.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace Functions
 
 module Json =

--- a/functions/Jwt.fs
+++ b/functions/Jwt.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace Functions
 
 open Types

--- a/functions/Logging.fs
+++ b/functions/Logging.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace Functions
 
 module Logging =

--- a/functions/Types.fs
+++ b/functions/Types.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace Functions
 
 open System

--- a/functions/Util.fs
+++ b/functions/Util.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace Functions
 
 module Util =

--- a/migrations/Migrations/01_CreateBaseTables.fs
+++ b/migrations/Migrations/01_CreateBaseTables.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace Migrations
 open SimpleMigrations
 

--- a/migrations/Migrations/02_CreateLogTable.fs
+++ b/migrations/Migrations/02_CreateLogTable.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace Migrations
 open SimpleMigrations
 

--- a/migrations/Program.fs
+++ b/migrations/Program.fs
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-﻿namespace Migrations
+namespace Migrations
     
 module Program =
 

--- a/migrations/Program.fs
+++ b/migrations/Program.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 ﻿namespace Migrations
     
 module Program =

--- a/scripts/ImportOrgData/Database.fs
+++ b/scripts/ImportOrgData/Database.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace ImportOrgData
 
 open Chessie.ErrorHandling

--- a/scripts/ImportOrgData/OrgTree.fs
+++ b/scripts/ImportOrgData/OrgTree.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace ImportOrgData
 
 open System

--- a/scripts/ImportOrgData/Program.fs
+++ b/scripts/ImportOrgData/Program.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 ﻿namespace ImportOrgData
 
 open Types

--- a/scripts/ImportOrgData/Types.fs
+++ b/scripts/ImportOrgData/Types.fs
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 namespace ImportOrgData
 
 module Types =


### PR DESCRIPTION
IU's open source policy requires that we add this banner to the top of every source file. This PR adds an recursive, repeatable script that will keep our source files in compliance. Just run `add-copyright.sh` and Bob's your uncle.