### PR TITLE
Add validation step to prevent circular unit relationships.

### DIFF
--- a/functions.tests.integration/DatabaseTests.fs
+++ b/functions.tests.integration/DatabaseTests.fs
@@ -131,4 +131,20 @@ module DatabaseTests=
             match actual with 
             | Bad([(status, msg)]) -> status |> should equal Status.NotFound
             | _ -> System.Exception("Should have failed") |> raise
+
+        [<Fact>]
+        member __.``Gets unit when descended from parent`` () = 
+            // This request should return parksAndRec because it is a child unit of the City of Pawnee
+            let actual = repo.Units.GetDescendantOfParent cityOfPawnee parksAndRec.Id |> awaitAndUnpack
+            
+            actual.IsSome |> should be True
+            actual.Value.Name |> should equal (parksAndRec.Name)
+ 
+        [<Fact>]
+        member __.``Doesn't get unit when not descended from parent`` () = 
+            // This request should not return parksAndRec because it is not a child unit the Fourth Floor
+            let actual = repo.Units.GetDescendantOfParent fourthFloor parksAndRec.Id |> awaitAndUnpack
+            
+            actual.IsNone |> should be True
+        
             

--- a/functions/Fakes.fs
+++ b/functions/Fakes.fs
@@ -171,6 +171,7 @@ module Fakes =
         GetMembers = fun unit -> stub ([ swansonMembership ] |> List.toSeq) 
         GetChildren = fun unit -> stub ([ fourthFloor ] |> List.toSeq) 
         GetSupportedDepartments = fun unit -> stub ([ supportRelationship ] |> List.toSeq) 
+        GetDescendantOfParent = fun parent childId -> stub None
         Create = fun unit -> stub parksAndRec
         Update = fun unit -> stub parksAndRec
         Delete = fun unit -> stub ()

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -230,19 +230,14 @@ module Functions =
     let testForCircularDependency (u:Unit) (child:Unit option) =    
         match (child) with
         | Some(c) -> 
-            printfn "Found child %A" c
             let error = sprintf "Whoops! %s is a parent of %s in the unit hierarcy. Adding it as a child would result in a circular relationship. 🙃" u.Name c.Name
             fail(Status.Conflict, error)
-        | None -> 
-            printfn "Didn't find any child."
-            (ok u)
+        | None -> ok u
     
-
     let validateUnitParentIsNotCircular (u:Unit) = async {
         match u.ParentId with
         | None -> return (ok u)
         | Some(parentId) ->    
-            printfn "Got Parent ID %d." parentId                    
             return 
                 parentId
                 |> await (data.Units.GetDescendantOfParent u) 

--- a/functions/Types.fs
+++ b/functions/Types.fs
@@ -279,6 +279,8 @@ module Types =
         Update: Unit -> Async<Result<Unit,Error>>
         /// Delete a unit
         Delete: Unit -> Async<Result<unit,Error>>
+        /// 
+        GetDescendantOfParent: Unit -> Id -> Async<Result<Unit option,Error>>
     }
 
     type DepartmentRepository = {


### PR DESCRIPTION
When adding a child unit, it's possible (though unlikely) for a user to try to add, as a child a unit, a  top-level unit that happens to be at the top of the current unit's org tree. Take for example the following org structure:
```
Executive Unit -> Group Unit -> Team Unit
```
If a user attempted to add `Executive Unit` as a child of `Team Unit`, a circular relationship would result. 

This PR validates that a circular relationship would not be created when creating/updating `Unit` records.