### PR TITLE
Observe unit member permissions

### DIFF
--- a/core/Types.fs
+++ b/core/Types.fs
@@ -404,6 +404,12 @@ type HrDataRepository = {
     GetAllPeople: Filter option -> Async<Result<Person seq,Error>>
 }
 
+type AuthorizationRepository = {
+    IsServiceAdmin: NetId -> Async<Result<bool, Error>>
+    IsUnitManager: NetId -> Id -> Async<Result<bool, Error>>
+    IsUnitToolManager: NetId -> Id -> Async<Result<bool, Error>>
+}
+
 type DataRepository = {
     People: PeopleRepository
     Units: UnitRepository
@@ -413,6 +419,7 @@ type DataRepository = {
     Tools: ToolsRepository
     SupportRelationships: SupportRelationshipRepository
     Hr: HrDataRepository
+    Authorization: AuthorizationRepository
 }
 
 let stub a = a |> Ok |> async.Return

--- a/core/Types.fs
+++ b/core/Types.fs
@@ -19,6 +19,8 @@ let compose (f : 'a -> Async<Result<'b, 'e>>) (g : 'b -> Async<Result<'c, 'e>>) 
 let (>>=) a f = bind f a
 let (>=>) f g = compose f g
 let ar = async.Return
+let ok x = x |> Ok |> async.Return
+let error(status, msg) = Error(status, msg) |> async.Return  
 
 let ROLE_ADMIN = "admin"
 let ROLE_USER = "user"

--- a/core/Types.fs
+++ b/core/Types.fs
@@ -386,6 +386,8 @@ type MemberToolsRepository = {
     Update: MemberTool -> Async<Result<MemberTool,Error>>
     /// Delete a unit membership
     Delete: MemberTool -> Async<Result<unit,Error>>
+    // Get the membership that goes along with the member tool.
+    GetMember: MemberTool -> Async<Result<MemberTool*UnitMember,Error>>
 }
 
 type SupportRelationshipRepository = {

--- a/functions/Authorization.fs
+++ b/functions/Authorization.fs
@@ -1,0 +1,26 @@
+module Functions.Authorization
+
+open System
+open Core.Types
+
+/// Temporary: a list of IT people admins.
+let isAdmin (user:JwtClaims) =
+    let admins = [ "jhoerr"; "kendjone"; "jerussel"; "brrund"; "mattzink"; "johndoe" ]
+    admins |> List.contains user.UserName
+
+let parseAuthResult model result =
+    if result
+    then Ok model |> ar
+    else Error (Status.Forbidden, "You are not authorized to modify this resource.") |> ar
+
+let canCreateDeleteUnit auth model user  =
+    auth.IsServiceAdmin user.UserName
+    >>= parseAuthResult model
+
+let canModifyUnit auth model user =
+    auth.IsUnitManager user.UserName 0
+    >>= parseAuthResult model
+
+let canModifyUnitMemberTools auth model user = 
+    auth.IsUnitToolManager user.UserName 0
+    >>= parseAuthResult model

--- a/functions/DatabaseRepository.fs
+++ b/functions/DatabaseRepository.fs
@@ -433,6 +433,12 @@ module DatabaseRepository =
         GetAllPeople = lookupCanonicalHrPeople sharedSecret
     }
 
+    let AuthorizationRepository(connStr) = {
+        IsServiceAdmin = fun id -> new System.NotImplementedException () |> raise
+        IsUnitManager = fun netid id -> new System.NotImplementedException () |> raise
+        IsUnitToolManager = fun netid id -> new System.NotImplementedException () |> raise
+    }
+
     let Repository(connStr, sharedSecret) = {
         People = People(connStr)
         Departments = Departments(connStr)
@@ -442,4 +448,5 @@ module DatabaseRepository =
         Tools = ToolsRepository(connStr)
         SupportRelationships = SupportRelationshipsRepository(connStr)
         Hr = HrRepository(sharedSecret)
+        Authorization = AuthorizationRepository(connStr)
     }

--- a/functions/DatabaseRepository.fs
+++ b/functions/DatabaseRepository.fs
@@ -358,6 +358,10 @@ module DatabaseRepository =
 
     let deleteMemberTool connStr memberTool =
         delete<MemberTool> connStr (identity memberTool)
+
+    let getMemberToolMember connStr (memberTool:MemberTool) =
+        queryMembership connStr memberTool.MembershipId
+        >>= fun membership -> ok (memberTool, membership)
    
     // *********************
     // HR Lookups
@@ -469,6 +473,7 @@ module DatabaseRepository =
         Create = insertMemberTool connStr
         Update = updateMemberTool connStr
         Delete = deleteMemberTool connStr
+        GetMember = getMemberToolMember connStr
     }
 
     let ToolsRepository (connStr) : ToolsRepository = {

--- a/functions/DatabaseRepository.fs
+++ b/functions/DatabaseRepository.fs
@@ -395,21 +395,17 @@ module DatabaseRepository =
        FROM units u
        INNER JOIN parentage p ON p.parent_id = u.id
     ) 
-    SELECT 
-    	-- select 'true' if this person has the specified permissions
-    	-- in this unit or any parent unit and 'false' otherwise.
-    	CASE WHEN EXISTS (
-    		SELECT pa.id, um.role, pe.netid
-    		FROM parentage pa
-    		JOIN unit_members um on pa.id = um.unit_id
-    		JOIN people pe on pe.id = um.person_id 
-    		WHERE
-    			pe.netid = @NetId 
-    			AND um.permissions = ANY(@UnitPermissions)
-    	) 
-    	THEN TRUE
-    	ELSE FALSE
-    	END"""
+	-- select 'true' if this person has the specified permissions
+	-- in this unit or any parent unit and 'false' otherwise.
+    SELECT EXISTS (
+		SELECT pa.id, um.role, pe.netid
+		FROM parentage pa
+		JOIN unit_members um on pa.id = um.unit_id
+		JOIN people pe on pe.id = um.person_id 
+		WHERE
+			pe.netid = @NetId 
+			AND um.permissions = ANY(@UnitPermissions)
+    ) """
 
     type AuthParams = {UnitId: Id; NetId: NetId; UnitPermissions: int[]}
 

--- a/functions/FakesRepository.fs
+++ b/functions/FakesRepository.fs
@@ -51,6 +51,7 @@ module FakesRepository =
         Create = fun req -> stub memberTool
         Update = fun req -> stub memberTool
         Delete = fun id -> stub ()
+        GetMember = fun tool -> stub (tool, knopeMembership)
     }
 
     let FakeToolsRepository : ToolsRepository = {

--- a/functions/FakesRepository.fs
+++ b/functions/FakesRepository.fs
@@ -69,6 +69,12 @@ module FakesRepository =
     let FakeHr = {
         GetAllPeople = fun query -> stub ([ swanson ] |> List.toSeq)
     }
+
+    let FakeAuthorization : AuthorizationRepository = {
+        IsServiceAdmin = fun id -> stub true
+        IsUnitManager = fun netid id -> stub true
+        IsUnitToolManager = fun netid id -> stub true
+    }
     
     let Repository = {
         People = FakePeople
@@ -79,5 +85,6 @@ module FakesRepository =
         Tools = FakeToolsRepository
         SupportRelationships = FakeSupportRelationships
         Hr = FakeHr
+        Authorization = FakeAuthorization
     }
 

--- a/functions/functions.fsproj
+++ b/functions/functions.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="Api.fs" />
     <Compile Include="DatabaseRepository.fs" />
     <Compile Include="FakesRepository.fs" />
+    <Compile Include="Authorization.fs" />
     <Compile Include="Validation.fs" />
     <Compile Include="Functions.fs" />
     <None Include="host.json">


### PR DESCRIPTION
A new `AuthorizationRepository` has been created that will determine whether a given user has a given set of permissions, on a per-unit basis. This repository is used both to authorize incoming actions, and to determine the values of the `X-User-Permissions` response header.

Since authorization is typically scoped to the unit, I had to jump through a few hoops in order to authorize actions on related collections, such as memberships, member tools, and support relationships. If this obscures the intent of the functions too much, I can take another swing at refactoring them.