### PR TITLE
Check for directory record when adding unit member by netid

### DIFF
--- a/functions.tests.integration/ContractTests.fs
+++ b/functions.tests.integration/ContractTests.fs
@@ -38,7 +38,7 @@ module ContractTests =
                 .PactUri("https://raw.githubusercontent.com/indiana-university/itpeople-app/develop/contracts/itpeople-app-itpeople-functions.json")
                 .Verify()
 
-        // [<Fact>]
+        [<Fact>]
         member __.``Verify Contracts`` () = async {
             let mutable stateServer = None
             try

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -627,6 +627,10 @@ module Functions =
 
     let setRelationshipId id (a:SupportRelationship) = Ok { a with Id=id } |> async.Return
     let relationshipValidator = supportRelationshipValidator data
+    let authorizeSupportRelationshipUnitModification req (rel:SupportRelationship) =
+        authorize req (canModifyUnit rel.UnitId) rel
+    let permissionSupportRelationshipUnitModification req (rel:SupportRelationship) =
+        permission req (canModifyUnit rel.UnitId) rel
 
     [<FunctionName("SupportRelationshipsGetAll")>]
     [<SwaggerOperation(Summary="List all unit-department support relationships.", Tags=[|"Support Relationships"|])>]
@@ -647,7 +651,7 @@ module Functions =
         let workflow =
             authenticate
             >=> fun _ -> data.SupportRelationships.Get relationshipId
-            >=> fun rel -> permission req (canModifyUnit rel.UnitId) rel
+            >=> permissionSupportRelationshipUnitModification req
         get req workflow
 
     [<FunctionName("SupportRelationshipsCreate")>]
@@ -663,7 +667,7 @@ module Functions =
             deserializeBody<SupportRelationship>
             >=> setRelationshipId 0
             >=> relationshipValidator.ValidForCreate
-            >=> fun sr -> authorize req (canModifyUnit sr.UnitId) sr
+            >=> authorizeSupportRelationshipUnitModification req
             >=> data.SupportRelationships.Create          
         create req workflow
 
@@ -682,7 +686,7 @@ module Functions =
             >=> setRelationshipId relationshipId
             >=> ensureEntityExistsForModel data.SupportRelationships.Get
             >=> relationshipValidator.ValidForUpdate
-            >=> fun sr -> authorize req (canModifyUnit sr.UnitId) sr
+            >=> authorizeSupportRelationshipUnitModification req
             >=> data.SupportRelationships.Update
         update req workflow
 
@@ -696,7 +700,7 @@ module Functions =
         let workflow = 
             fun _ -> data.SupportRelationships.Get relationshipId
             >=> relationshipValidator.ValidForDelete
-            >=> fun sr -> authorize req (canModifyUnit sr.UnitId) sr
+            >=> authorizeSupportRelationshipUnitModification req
             >=> data.SupportRelationships.Delete
         delete req workflow
 

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -489,6 +489,10 @@ module Functions =
 
     let memberToolValidator = memberToolValidator(data)
     let setMemberToolId id (a:MemberTool) = Ok { a with Id=id } |> async.Return
+    let authorizeMemberToolUnitModification req (tool:MemberTool,unitMember:UnitMember) =
+        authorize req (canModifyUnitMemberTools unitMember.UnitId) tool
+    let permissionMemberToolUnitModification req (tool:MemberTool,unitMember:UnitMember) =
+        permission req (canModifyUnitMemberTools unitMember.UnitId) tool
 
     [<FunctionName("MemberToolsGetAll")>]
     [<SwaggerOperation(Summary="List all unit member tools", Tags=[|"Unit Member Tools"|])>]
@@ -510,7 +514,7 @@ module Functions =
             authenticate
             >=> fun _ -> data.MemberTools.Get memberToolId
             >=> data.MemberTools.GetMember 
-            >=> fun (tool,unitMember) -> permission req (canModifyUnitMemberTools unitMember.UnitId) tool
+            >=> permissionMemberToolUnitModification req
         get req workflow
 
     [<FunctionName("MemberToolCreate")>]
@@ -527,7 +531,7 @@ module Functions =
             >=> setMemberToolId 0
             >=> memberToolValidator.ValidForCreate
             >=> data.MemberTools.GetMember 
-            >=> fun (tool,unitMember) -> authorize req (canModifyUnitMemberTools unitMember.UnitId) tool
+            >=> authorizeMemberToolUnitModification req
             >=> data.MemberTools.Create
         create req workflow
 
@@ -547,7 +551,7 @@ module Functions =
             >=> ensureEntityExistsForModel data.MemberTools.Get
             >=> memberToolValidator.ValidForUpdate
             >=> data.MemberTools.GetMember  
-            >=> fun (tool,unitMember) -> authorize req (canModifyUnitMemberTools unitMember.UnitId) tool
+            >=> authorizeMemberToolUnitModification req
             >=> data.MemberTools.Update
         update req workflow
 
@@ -563,7 +567,7 @@ module Functions =
             fun _ -> data.MemberTools.Get memberToolId
             >=> memberToolValidator.ValidForDelete
             >=> data.MemberTools.GetMember  
-            >=> fun (tool,unitMember) -> authorize req (canModifyUnitMemberTools unitMember.UnitId) tool
+            >=> authorizeMemberToolUnitModification req
             >=> data.MemberTools.Delete
         delete req workflow
 

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -376,7 +376,7 @@ module Functions =
     let setMembershipId id (a:UnitMember) = Ok { a with Id=id } |> async.Return
     let authorizeMembershipUnitModification req (membership:UnitMember) =
         authorize req (canModifyUnit membership.UnitId) membership
-    let permissionMembership req (membership:UnitMember) =
+    let permissionMembershipUnitModification req (membership:UnitMember) =
         permission req (canModifyUnit membership.UnitId) membership     
 
     [<FunctionName("MemberGetAll")>]
@@ -398,7 +398,7 @@ module Functions =
         let workflow = 
             authenticate
             >=> fun _ -> data.Memberships.Get membershipId
-            >=> permissionMembership req
+            >=> permissionMembershipUnitModification req
         get req workflow
 
     let ensurePersonInDirectory lookupDirectoryPeople lookupHrPeople addPersonToDirectory (um:UnitMember) =


### PR DESCRIPTION
This PR fixes a contract breakage. When adding a unit member by netid it was assumed that the person wouldn't already be in the directory. The directory is now searched prior to doing an HR data lookup. This is the correct behavior, and fixes the test.

Also refactors a few permission/authorization flows to make them more clear.