### PR TITLE
Query DB for "service admin" entitlement

### DIFF
--- a/core/Fakes.fs
+++ b/core/Fakes.fs
@@ -30,6 +30,7 @@ let swanson:Person = {
     Responsibilities = Responsibilities.ItLeadership
     DepartmentId=parksDept.Id
     Department=parksDept
+    IsServiceAdmin=false
 }
 
 let knope:Person = {
@@ -47,6 +48,7 @@ let knope:Person = {
     Responsibilities = Responsibilities.ItLeadership ||| Responsibilities.ItProjectMgt
     DepartmentId=parksDept.Id
     Department=parksDept
+    IsServiceAdmin=false
 }
 
 let wyatt:Person = {
@@ -64,6 +66,7 @@ let wyatt:Person = {
     Responsibilities = Responsibilities.ItProjectMgt
     DepartmentId=parksDept.Id
     Department=parksDept
+    IsServiceAdmin=false
 }
 
 let tool: Tool = 

--- a/core/Fakes.fs
+++ b/core/Fakes.fs
@@ -69,6 +69,24 @@ let wyatt:Person = {
     IsServiceAdmin=false
 }
 
+let admin = {
+    Id=3
+    NetId="johndoe"
+    Name="Doe, John"
+    Position="Admin"
+    Location=""
+    Campus=""
+    CampusPhone=""
+    CampusEmail="johndoe@pawnee.in.us"
+    Expertise="Services; Administration"
+    Notes=""
+    PhotoUrl=""
+    Responsibilities = Responsibilities.None
+    DepartmentId=parksDept.Id
+    Department=parksDept
+    IsServiceAdmin=true
+}
+
 let tool: Tool = 
   { Id=1
     Name="Hammer"

--- a/core/Types.fs
+++ b/core/Types.fs
@@ -143,6 +143,8 @@ type Person =
     [<Column("responsibilities")>] Responsibilities: Responsibilities
     /// The HR department to which this person belongs.
     [<Column("department_id")>] DepartmentId: Id
+    /// Whether this person is an administrator of the IT People service.
+    [<Column("is_service_admin")>] IsServiceAdmin: bool
     /// The department in this relationship.
     [<ReadOnly(true)>] Department: Department }
 

--- a/database/Fakes.fs
+++ b/database/Fakes.fs
@@ -41,6 +41,7 @@ module Fakes =
         db.Insert<Person>(swanson) |> ignore
         db.Insert<Person>(knope) |> ignore
         db.Insert<Person>(wyatt) |> ignore
+        db.Insert<Person>(admin) |> ignore
         // unit membership
         db.Insert<UnitMember>(swansonMembership) |> ignore
         db.Insert<UnitMember>(knopeMembership) |> ignore

--- a/database/Migrations/07_AddPersonServiceAdminColumn.fs
+++ b/database/Migrations/07_AddPersonServiceAdminColumn.fs
@@ -1,0 +1,26 @@
+
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
+namespace Migrations
+open SimpleMigrations
+
+// Table Modified
+// Column Modified
+// Timestamp
+// Username of the individual who made the change
+// Change type (Add/Delete)
+// Value added or removed
+
+[<Migration(7L, "Add person service admin column")>]
+type AddPersonServiceAdminColumn() =
+  inherit Migration()
+  override __.Up() =
+    base.Execute("""
+    ALTER TABLE people ADD COLUMN is_service_admin BOOLEAN NOT NULL DEFAULT FALSE;
+    """)
+
+  override __.Down() =
+    base.Execute("""
+    ALTER TABLE people DROP COLUMN is_service_admin;
+""")

--- a/database/Migrations/07_AddPersonServiceAdminColumn.fs
+++ b/database/Migrations/07_AddPersonServiceAdminColumn.fs
@@ -18,6 +18,10 @@ type AddPersonServiceAdminColumn() =
   override __.Up() =
     base.Execute("""
     ALTER TABLE people ADD COLUMN is_service_admin BOOLEAN NOT NULL DEFAULT FALSE;
+    
+    UPDATE people 
+    SET is_service_admin = true
+    WHERE netid IN ('jerussel', 'brrund', 'jhoerr', 'kendjone');
     """)
 
   override __.Down() =

--- a/database/database.fsproj
+++ b/database/database.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="Migrations/04_AlterToolsWithDepartmentScopeFlag.fs" />
     <Compile Include="Migrations/05_AddAuditTable.fs" />
     <Compile Include="Migrations/06_DropPersonHashColumn.fs" />
+    <Compile Include="Migrations/07_AddPersonServiceAdminColumn.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
For sake of expedience we've historically maintained a small list of people who should be granted an entitlement of 'service admin.' This PR shifts this entitlement to a new database column, `people.is_service_admin`.