### PR TITLE
Periodically update tool permission groups in AD

### DIFF
--- a/core/Fakes.fs
+++ b/core/Fakes.fs
@@ -91,6 +91,7 @@ let tool: Tool =
   { Id=1
     Name="Hammer"
     Description=""
+    ADPath=""
     DepartmentScoped=true }
 
 let memberTool:MemberTool = 

--- a/core/Json.fs
+++ b/core/Json.fs
@@ -51,6 +51,9 @@ let mapFlagsToSeq<'T when 'T :> System.Enum> (value: 'T) =
     |> Seq.map (fun s -> System.Enum.Parse(typeof<'T>,s.Trim()) :?> 'T)
     |> Seq.filter (fun e -> e.ToString() <> "None")
 
+let serialize x = 
+    JsonConvert.SerializeObject(x, JsonSettings)
+    
 let tryDeserialize<'T> status str =
     try JsonConvert.DeserializeObject<'T>(str, JsonSettings) |> Ok
     with exn -> Error (status, exn.Message)

--- a/core/Json.fs
+++ b/core/Json.fs
@@ -60,8 +60,8 @@ let tryDeserialize<'T> status str =
     try str |> deserialize<'T> |> Ok
     with exn -> Error (status, exn.Message)
 
-let tryDeserializeAsync<'T> (status:Status) str =
-    tryDeserialize<'T> status str |> ar
+let tryDeserializeAsync<'T> str =
+    tryDeserialize<'T> Status.BadRequest str |> ar
 
 /// Attempt to deserialize the request body as an object of the given type.
 let deserializeBody<'T> (req:HttpRequestMessage) = async { 

--- a/core/Json.fs
+++ b/core/Json.fs
@@ -53,10 +53,15 @@ let mapFlagsToSeq<'T when 'T :> System.Enum> (value: 'T) =
 
 let serialize x = 
     JsonConvert.SerializeObject(x, JsonSettings)
-    
+
+let deserialize<'T> str =
+    JsonConvert.DeserializeObject<'T>(str, JsonSettings)
 let tryDeserialize<'T> status str =
-    try JsonConvert.DeserializeObject<'T>(str, JsonSettings) |> Ok
+    try str |> deserialize<'T> |> Ok
     with exn -> Error (status, exn.Message)
+
+let tryDeserializeAsync<'T> (status:Status) str =
+    tryDeserialize<'T> status str |> ar
 
 /// Attempt to deserialize the request body as an object of the given type.
 let deserializeBody<'T> (req:HttpRequestMessage) = async { 

--- a/core/Types.fs
+++ b/core/Types.fs
@@ -227,7 +227,7 @@ type Tool =
     [<Column("description")>] Description: Name
     /// A description of this tool.
     [<DefaultValue("")>]
-    [<Column("description")>] ADPath: string
+    [<Column("ad_path")>] ADPath: string
     /// Whether this tool is scoped to a department via a unit-department support relationship.
     [<DefaultValue(false)>]
     [<Column("department_scoped")>] DepartmentScoped: bool }

--- a/core/Types.fs
+++ b/core/Types.fs
@@ -225,6 +225,9 @@ type Tool =
     /// A description of this tool.
     [<DefaultValue("")>]
     [<Column("description")>] Description: Name
+    /// A description of this tool.
+    [<DefaultValue("")>]
+    [<Column("description")>] ADPath: string
     /// Whether this tool is scoped to a department via a unit-department support relationship.
     [<DefaultValue(false)>]
     [<Column("department_scoped")>] DepartmentScoped: bool }

--- a/database/Migrations/08_AddToolAdPath.fs
+++ b/database/Migrations/08_AddToolAdPath.fs
@@ -1,0 +1,19 @@
+
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
+namespace Migrations
+open SimpleMigrations
+
+[<Migration(8L, "Add AD Path to Tool table")>]
+type AddToolAdPath() =
+  inherit Migration()
+  override __.Up() =
+    base.Execute("""
+    ALTER TABLE tools ADD COLUMN ad_path TEXT NOT NULL DEFAULT '';
+    """)
+
+  override __.Down() =
+    base.Execute("""
+    ALTER TABLE tools DROP COLUMN ad_path;
+""")

--- a/database/database.fsproj
+++ b/database/database.fsproj
@@ -15,13 +15,7 @@
     <Compile Include="Migration.fs" />
     <Compile Include="Command.fs" />
     <Compile Include="Fakes.fs" />
-    <Compile Include="Migrations/01_CreateBaseTables.fs" />
-    <Compile Include="Migrations/02_CreateToolTables.fs" />
-    <Compile Include="Migrations/03_ToolsAddDefaults.fs" />
-    <Compile Include="Migrations/04_AlterToolsWithDepartmentScopeFlag.fs" />
-    <Compile Include="Migrations/05_AddAuditTable.fs" />
-    <Compile Include="Migrations/06_DropPersonHashColumn.fs" />
-    <Compile Include="Migrations/07_AddPersonServiceAdminColumn.fs" />
+    <Compile Include="Migrations/*.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/docker-start-tasks.sh
+++ b/docker-start-tasks.sh
@@ -16,6 +16,8 @@ docker run \
 -e "AzureWebJobsDashboard=CHANGEME" \
 -e "SharedSecret=CHANGEME" \
 -e "DbConnectionString=CHANGEME" \
+-e "AdUser=CHANGEME" \
+-e "AdPassword=CHANGEME" \
 -e "FUNCTIONS_WORKER_RUNTIME=dotnet" \
 -e "WEBSITE_SITE_NAME=tasks" \
 -e "WEBSITE_INSTANCE_ID=tasks" \

--- a/functions.tests.unit/AdTests.fs
+++ b/functions.tests.unit/AdTests.fs
@@ -33,10 +33,13 @@ module AdTests =
     let ``list group members`` () =
         let fn (ldap:LdapConnection) = 
             printfn "Members of group..."
+            let mutable count = 0
             let search = ldap.Search(searchBase, 1, searchFilter, [|"cn"|], false)          
             while search.hasMore() do
                 let next = search.next()
                 printfn "  %s" (next.getAttribute("cn").StringValue)
+                count <- count + 1
+            printfn "  Found %d members." count
         doLdapThing fn
 
     //[<Fact>]

--- a/functions.tests.unit/AdTests.fs
+++ b/functions.tests.unit/AdTests.fs
@@ -10,10 +10,10 @@ module AdTests =
 
     let username = "CHANGEME"
     let password = "CHANGEME"
+    let dn = "CHANGEME"    
     let searchBase = "ou=Accounts,dc=ads,dc=iu,dc=edu"
-    let dn = "CHANGEME"
-    let searchFilter = sprintf "(memberOf=%s)" dn
-    let memberAttribute = LdapAttribute("member", sprintf "cn=opsbot,%s" searchBase)
+    let searchFilter = sprintf "(memberOf=%s)"
+    let memberAttribute netid = LdapAttribute("member", sprintf "cn=%s,%s" netid searchBase)
 
     let doLdapThing fn = 
         try
@@ -34,7 +34,7 @@ module AdTests =
         let fn (ldap:LdapConnection) = 
             printfn "Members of group..."
             let mutable count = 0
-            let search = ldap.Search(searchBase, 1, searchFilter, [|"cn"|], false)          
+            let search = ldap.Search(searchBase, 1, searchFilter dn, [|"cn"|], false)          
             while search.hasMore() do
                 let next = search.next()
                 printfn "  %s" (next.getAttribute("cn").StringValue)
@@ -46,7 +46,7 @@ module AdTests =
     let ``can add a member to group`` () =
         let addOpsbot (ldap:LdapConnection) =
             printfn "Add member to group..."
-            let modification = LdapModification(LdapModification.ADD, memberAttribute)
+            let modification = LdapModification(LdapModification.ADD, memberAttribute "opsbot")
             ldap.Modify(dn, modification)
         
         ``list group members``()
@@ -54,12 +54,11 @@ module AdTests =
         ``list group members``()
         ()
 
-
     // [<Fact>]
     let ``can remove a member from group`` () =
         let removeOpsbot (ldap:LdapConnection) =
             printfn "Remove member from group..."
-            let modification = LdapModification(LdapModification.DELETE, memberAttribute)
+            let modification = LdapModification(LdapModification.DELETE, memberAttribute "opsbot")
             ldap.Modify(dn, modification)
 
         ``list group members``()

--- a/functions.tests.unit/AdTests.fs
+++ b/functions.tests.unit/AdTests.fs
@@ -1,0 +1,66 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
+namespace Tests
+
+open Xunit
+open Novell.Directory.Ldap
+
+module AdTests =
+
+    let username = "CHANGEME"
+    let password = "CHANGEME"
+    let searchBase = "ou=Accounts,dc=ads,dc=iu,dc=edu"
+    let dn = "CHANGEME"
+    let searchFilter = sprintf "(memberOf=%s)" dn
+    let memberAttribute = LdapAttribute("member", sprintf "cn=opsbot,%s" searchBase)
+
+    let doLdapThing fn = 
+        try
+            use ldap = new LdapConnection()
+            let connected = System.DateTime.Now
+            ldap.Connect("ads.iu.edu", 389)
+            ldap.Bind(username, password)  
+            let started = System.DateTime.Now
+            ldap |> fn
+            let now = System.DateTime.Now
+            printfn "Time from connect: %f ms" ((now - connected).TotalMilliseconds)
+            printfn "Time from fn: %f ms" ((now - started).TotalMilliseconds)
+            ldap.Disconnect()
+        with exn -> printfn "PUUUUUKE 🤮 %A" exn
+
+    // [<Fact>]
+    let ``list group members`` () =
+        let fn (ldap:LdapConnection) = 
+            printfn "Members of group..."
+            let search = ldap.Search(searchBase, 1, searchFilter, [|"cn"|], false)          
+            while search.hasMore() do
+                let next = search.next()
+                printfn "  %s" (next.getAttribute("cn").StringValue)
+        doLdapThing fn
+
+    //[<Fact>]
+    let ``can add a member to group`` () =
+        let addOpsbot (ldap:LdapConnection) =
+            printfn "Add member to group..."
+            let modification = LdapModification(LdapModification.ADD, memberAttribute)
+            ldap.Modify(dn, modification)
+        
+        ``list group members``()
+        doLdapThing addOpsbot
+        ``list group members``()
+        ()
+
+
+    // [<Fact>]
+    let ``can remove a member from group`` () =
+        let removeOpsbot (ldap:LdapConnection) =
+            printfn "Remove member from group..."
+            let modification = LdapModification(LdapModification.DELETE, memberAttribute)
+            ldap.Modify(dn, modification)
+
+        ``list group members``()
+        doLdapThing removeOpsbot
+        ``list group members``()
+        ()
+

--- a/functions.tests.unit/JsonTests.fs
+++ b/functions.tests.unit/JsonTests.fs
@@ -30,3 +30,15 @@ module JsonTests =
           "description": "description"
         }"""
         Assert.Equal(expected, actual);
+
+    type DU =
+    | Foo of int * string
+    | Bar of string * string
+
+    [<Fact>]
+    let ``Serialize complex DU`` () = 
+      let expected = Foo(3, "hello")
+      let json = serialize expected
+      printfn "serialized: %s" json
+      let actual = deserialize<DU> json
+      Assert.Equal(expected, actual);

--- a/functions.tests.unit/JsonTests.fs
+++ b/functions.tests.unit/JsonTests.fs
@@ -38,6 +38,7 @@ module JsonTests =
     [<Fact>]
     let ``Serialize complex DU`` () = 
       let expected = Foo(3, "hello")
+      printfn "DU tostring: %A" expected
       let json = serialize expected
       printfn "serialized: %s" json
       let actual = deserialize<DU> json

--- a/functions.tests.unit/JsonTests.fs
+++ b/functions.tests.unit/JsonTests.fs
@@ -38,8 +38,8 @@ module JsonTests =
     [<Fact>]
     let ``Serialize complex DU`` () = 
       let expected = Foo(3, "hello")
-      printfn "DU tostring: %A" expected
+      // printfn "DU tostring: %A" expected
       let json = serialize expected
-      printfn "serialized: %s" json
+      // printfn "serialized: %s" json
       let actual = deserialize<DU> json
       Assert.Equal(expected, actual);

--- a/functions.tests.unit/functions.tests.fsproj
+++ b/functions.tests.unit/functions.tests.fsproj
@@ -11,12 +11,14 @@
     <Compile Include="JsonTests.fs" />
     <Compile Include="JwtUtilTests.fs" />
     <Compile Include="ApiTests.fs" />
+    <Compile Include="AdTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="2.3.8" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/functions/DatabaseRepository.fs
+++ b/functions/DatabaseRepository.fs
@@ -256,13 +256,20 @@ module DatabaseRepository =
     let mapPerson id = 
         mapPeople (WhereId("p.id", id))
 
+    type PeopleQueryParam = {
+        Query:string
+        Responsibilities:int
+        Interests:array<string>
+        InterestsRaw:string
+    }
+
     let queryPeople connStr (query:PeopleQuery) =
-        let param = {|
+        let param = {
             Query = if query.Query = "" then "" else like query.Query
             Responsibilities = query.Responsibilities
             Interests = query.Interests |> Array.map like
             InterestsRaw = query.Interests |> String.concat ""
-        |}
+        }
         // printfn "Query Param: %A" param
         let whereClause = 
             """(@Query='' OR (p.name ILIKE @Query OR p.netid ILIKE @Query))

--- a/tasks/Functions.fs
+++ b/tasks/Functions.fs
@@ -83,7 +83,7 @@ module DataRepository =
             JOIN unit_members um ON um.person_id = p.id
             JOIN unit_member_tools umt ON umt.membership_id = um.id
             WHERE umt.tool_id = @Id"""
-        let param = {|Id=tool.Id|}
+        let param = {Id=tool.Id}
         fetch connStr (fun cn -> cn.QueryAsync<NetId>(sql, param))
 
     // LDAP Stuff

--- a/tasks/tasks.fsproj
+++ b/tasks/tasks.fsproj
@@ -15,11 +15,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
-    <!-- <PackageReference Include="Dapper" Version="1.50.5" /> -->
-    <!-- <PackageReference Include="Dapper.SimpleCRUD" Version="2.0.0" /> -->
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.27" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
-    <!-- <PackageReference Include="Npgsql" Version="4.0.3" /> -->
+    <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="2.3.8" />
   </ItemGroup>
 </Project>

--- a/tasks/tasks.fsproj
+++ b/tasks/tasks.fsproj
@@ -19,5 +19,9 @@
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="2.3.8" />
+    <PackageReference Include="Dapper" Version="1.50.5" />
+    <PackageReference Include="Dapper.SimpleCRUD" Version="2.0.0" />
+    <PackageReference Include="Npgsql" Version="4.0.3" />
+
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Every tool has an AD group associated with it. These tasks will reconcile the memberships of those AD groups with the current tool assignments for IT people.

The paths to the AD groups are stored in the database as part of the tool record. For production we will point to some sandbox AD groups. When ITCP is ready to start updating the real groups, we can simply update the DB records to point to the real groups.