### PR TITLE
Accept any valid UAA token for authorization

### DIFF
--- a/core/Fakes.fs
+++ b/core/Fakes.fs
@@ -4,15 +4,7 @@ open Types
 
 // UaaResponse 
 let uaaJwt = { access_token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX25hbWUiOiJqb2huZG9lIiwiZXhwIjoyOTE2MjM5MDIyfQ.ELo8I2IImgRRT75cOcUcSllbkWVWAIQA2WQr27WSpWwF2c7Wh9hjqkPriZ4PxSD4OR9IgGWt5HWpPQFDOwlv1O7tl2gLcZ5LayuRzQX2AEn-UsEBECStEwABUtwhg92q9Ov-GRbYqmP_5UpntbCr8aZfMEuMfLTIWePcORq_FrJhjyRUoKhUo8007W6RO58n03erVlslSB1f-JTYtBdhYOlgmDTOCp_rc-gPvKFePMb4c05IOD-x4ce2QGkZlL_pE1_OLKdn5A07k7B8x53v38WvWuisFGIPXUcuP3j9hdJHIzYLSfL5t1OABT1-57C91yaMAgVsATMRgT9qtzYQgg" }
-let fakePublicKey = """-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnzyis1ZjfNB0bBgKFMSv
-vkTtwlvBsaJq7S5wA+kzeVOVpVWwkWdVha4s38XM/pa/yr47av7+z3VTmvDRyAHc
-aT92whREFpLv9cj5lTeJSibyr/Mrm/YtjCZVWgaOYIhwrXwKLqPr/11inWsAkfIy
-tvHWTxZYEcXLgAXFuUuaS3uF9gEiNQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0
-e+lf4s4OxQawWD79J9/5d3Ry0vbV3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWb
-V6L11BWkpzGXSW4Hv43qa+GSYOD2QU68Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9
-MwIDAQAB
------END PUBLIC KEY-----"""
+let fakePublicKey = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnzyis1ZjfNB0bBgKFMSv\nvkTtwlvBsaJq7S5wA+kzeVOVpVWwkWdVha4s38XM/pa/yr47av7+z3VTmvDRyAHc\naT92whREFpLv9cj5lTeJSibyr/Mrm/YtjCZVWgaOYIhwrXwKLqPr/11inWsAkfIy\ntvHWTxZYEcXLgAXFuUuaS3uF9gEiNQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0\ne+lf4s4OxQawWD79J9/5d3Ry0vbV3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWb\nV6L11BWkpzGXSW4Hv43qa+GSYOD2QU68Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9\nMwIDAQAB\n-----END PUBLIC KEY-----"
 // Units
 let cityOfPawnee:Unit = {Id=1; Name="City of Pawnee"; Description="City of Pawnee, Indiana"; Url="http://pawneeindiana.com/"; ParentId=None; Parent=None}
 let parksAndRec:Unit = {Id=2; Name="Parks and Rec"; Description="Parks and Recreation"; Url="http://pawneeindiana.com/parks-and-recreation/"; ParentId=Some(cityOfPawnee.Id); Parent=Some(cityOfPawnee)}

--- a/core/Fakes.fs
+++ b/core/Fakes.fs
@@ -3,8 +3,16 @@ module Core.Fakes
 open Types
 
 // UaaResponse 
-let accessToken = { access_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOiIxNTE1NTQ0NjQzIiwidXNlcl9pZCI6MSwidXNlcl9uYW1lIjoiam9obmRvZSIsInVzZXJfcm9sZSI6ImFkbWluIn0.akuT7-xDFxrev-T9Dv0Wdumx1HK5L2hQAOU51igIjUE" }
-
+let uaaJwt = { access_token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX25hbWUiOiJqb2huZG9lIiwiZXhwIjoyOTE2MjM5MDIyfQ.ELo8I2IImgRRT75cOcUcSllbkWVWAIQA2WQr27WSpWwF2c7Wh9hjqkPriZ4PxSD4OR9IgGWt5HWpPQFDOwlv1O7tl2gLcZ5LayuRzQX2AEn-UsEBECStEwABUtwhg92q9Ov-GRbYqmP_5UpntbCr8aZfMEuMfLTIWePcORq_FrJhjyRUoKhUo8007W6RO58n03erVlslSB1f-JTYtBdhYOlgmDTOCp_rc-gPvKFePMb4c05IOD-x4ce2QGkZlL_pE1_OLKdn5A07k7B8x53v38WvWuisFGIPXUcuP3j9hdJHIzYLSfL5t1OABT1-57C91yaMAgVsATMRgT9qtzYQgg" }
+let fakePublicKey = """-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnzyis1ZjfNB0bBgKFMSv
+vkTtwlvBsaJq7S5wA+kzeVOVpVWwkWdVha4s38XM/pa/yr47av7+z3VTmvDRyAHc
+aT92whREFpLv9cj5lTeJSibyr/Mrm/YtjCZVWgaOYIhwrXwKLqPr/11inWsAkfIy
+tvHWTxZYEcXLgAXFuUuaS3uF9gEiNQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0
+e+lf4s4OxQawWD79J9/5d3Ry0vbV3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWb
+V6L11BWkpzGXSW4Hv43qa+GSYOD2QU68Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9
+MwIDAQAB
+-----END PUBLIC KEY-----"""
 // Units
 let cityOfPawnee:Unit = {Id=1; Name="City of Pawnee"; Description="City of Pawnee, Indiana"; Url="http://pawneeindiana.com/"; ParentId=None; Parent=None}
 let parksAndRec:Unit = {Id=2; Name="Parks and Rec"; Description="Parks and Recreation"; Url="http://pawneeindiana.com/parks-and-recreation/"; ParentId=Some(cityOfPawnee.Id); Parent=Some(cityOfPawnee)}

--- a/core/Types.fs
+++ b/core/Types.fs
@@ -46,7 +46,6 @@ type AppConfig =
     OAuth2ClientSecret: string
     OAuth2TokenUrl: string
     OAuth2RedirectUrl: string
-    JwtSecret: string
     DbConnectionString: string
     UseFakes: bool
     CorsHosts: string
@@ -422,6 +421,8 @@ type HrDataRepository = {
 }
 
 type AuthorizationRepository = {
+    /// Given an OAuth token_key URL and return the public key.
+    UaaPublicKey: string -> Async<Result<string,Error>>
     IsServiceAdmin: NetId -> Async<Result<bool, Error>>
     IsUnitManager: NetId -> Id -> Async<Result<bool, Error>>
     IsUnitToolManager: NetId -> Id -> Async<Result<bool, Error>>

--- a/functions.tests.integration/ApiErrorTests.fs
+++ b/functions.tests.integration/ApiErrorTests.fs
@@ -20,7 +20,7 @@ module ApiErrorTests =
         new HttpRequestMessage(method, uri)
 
     let withAuthentication (request:HttpRequestMessage) = 
-        request.Headers.Authorization <- AuthenticationHeaderValue("Bearer", "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOiIxOTE1NTQ0NjQzIiwidXNlcl9uYW1lIjoiam9obmRvZSIsInVzZXJfaWQiOjF9.bCMuAfRby19tJHCOggz7KESMRxtPl_h7pLTQTx3ui4E")
+        request.Headers.Authorization <- AuthenticationHeaderValue("Bearer", Core.Fakes.uaaJwt.access_token)
         request
     
     let withRawBody str (request:HttpRequestMessage) =

--- a/functions.tests.integration/ContractTests.fs
+++ b/functions.tests.integration/ContractTests.fs
@@ -35,7 +35,7 @@ module ContractTests =
                 .ProviderState(stateServerUrl)
                 .ServiceProvider("API", functionServerUrl)
                 .HonoursPactWith("Client")
-                .PactUri("https://raw.githubusercontent.com/indiana-university/itpeople-app/develop/contracts/itpeople-app-itpeople-functions.json")
+                .PactUri("https://raw.githubusercontent.com/indiana-university/itpeople-app/feature/uaa-jwt/contracts/itpeople-app-itpeople-functions.json")
                 .Verify()
 
         [<Fact>]

--- a/functions.tests.integration/ContractTests.fs
+++ b/functions.tests.integration/ContractTests.fs
@@ -35,7 +35,7 @@ module ContractTests =
                 .ProviderState(stateServerUrl)
                 .ServiceProvider("API", functionServerUrl)
                 .HonoursPactWith("Client")
-                .PactUri("https://raw.githubusercontent.com/indiana-university/itpeople-app/feature/uaa-jwt/contracts/itpeople-app-itpeople-functions.json")
+                .PactUri("https://raw.githubusercontent.com/indiana-university/itpeople-app/develop/contracts/itpeople-app-itpeople-functions.json")
                 .Verify()
 
         [<Fact>]

--- a/functions.tests.integration/Scaffolding/TestFixture.fs
+++ b/functions.tests.integration/Scaffolding/TestFixture.fs
@@ -52,7 +52,7 @@ module TestFixture =
         do
             // These config settings are needed for the tests
             Environment.SetEnvironmentVariable("UseFakeData", "false")
-            Environment.SetEnvironmentVariable("JwtSecret","jwt signing secret")
+            Environment.SetEnvironmentVariable("OAuthPublicKey",Core.Fakes.fakePublicKey)
             Environment.SetEnvironmentVariable("DbConnectionString", testConnectionString)
             // These config settings aren't needed for the tests, but the config expects them
             Environment.SetEnvironmentVariable("OAuthClientId","na")

--- a/functions.tests.unit/TestFakes.fs
+++ b/functions.tests.unit/TestFakes.fs
@@ -29,7 +29,6 @@ module TestFakes =
         OAuth2ClientSecret="client secret"
         OAuth2TokenUrl="token url"
         OAuth2RedirectUrl="redirect url"
-        JwtSecret=jwtSingingSecret
         DbConnectionString="db connectionString"
         UseFakes=false
         CorsHosts="*"

--- a/functions/Api.fs
+++ b/functions/Api.fs
@@ -47,7 +47,6 @@ let getConfiguration () =
         OAuth2ClientSecret = getRequiredValue<string> config "OAuthClientSecret"
         OAuth2TokenUrl = getRequiredValue<string> config "OAuthTokenUrl"
         OAuth2RedirectUrl = getRequiredValue<string> config "OAuthRedirectUrl"
-        JwtSecret = getRequiredValue<string> config "JwtSecret"
         DbConnectionString = getRequiredValue<string> config "DbConnectionString"
         UseFakes = getValueOrDefault<bool> config "UseFakeData" false
         CorsHosts = getValueOrDefault<string> config "CorsHosts" "*"

--- a/functions/DatabaseRepository.fs
+++ b/functions/DatabaseRepository.fs
@@ -400,10 +400,16 @@ module DatabaseRepository =
         LIMIT 1
     )"""
 
+    type UaaPublicKey = {alg:string; value:string} 
+    let uaaPublicKey (url:string) =
+        let msg = new HttpRequestMessage(HttpMethod.Get, url)
+        sendAsync<UaaPublicKey> msg
+        >>= fun resp -> ok resp.value
+
     let isServiceAdmin connStr netid =
         let param = { NetId=netid }
         let query (cn:Cn) = cn.QuerySingleAsync<bool>(isServiceAdminSql, param)
-        fetch connStr query
+        fetch connStr query        
 
     let hasCascadedUnitPermsSql = """
     WITH RECURSIVE parentage AS (
@@ -515,6 +521,7 @@ module DatabaseRepository =
     }
 
     let AuthorizationRepository(connStr) = {
+        UaaPublicKey = uaaPublicKey
         IsServiceAdmin = isServiceAdmin connStr
         IsUnitManager = isUnitManager connStr
         IsUnitToolManager = isUnitToolManager connStr

--- a/functions/Examples.fs
+++ b/functions/Examples.fs
@@ -12,7 +12,7 @@ type ApiEndpointExample<'T>(example:'T) =
     interface IExamplesProvider<'T> with
         member this.GetExamples () = ex
 
-type JwtResponseExample () = inherit ApiEndpointExample<JwtResponse>(accessToken)
+type JwtResponseExample () = inherit ApiEndpointExample<JwtResponse>(uaaJwt)
 type UnitsExample() = inherit ApiEndpointExample<seq<Unit>>([parksAndRec])
 type UnitExample() = inherit ApiEndpointExample<Unit>(parksAndRec)
 type UnitRequestExample() = inherit ApiEndpointExample<UnitRequest>(parksAndRecUnitRequest)

--- a/functions/FakesRepository.fs
+++ b/functions/FakesRepository.fs
@@ -72,6 +72,7 @@ module FakesRepository =
     }
 
     let FakeAuthorization : AuthorizationRepository = {
+        UaaPublicKey = fun _ -> stub uaaJwt.access_token
         IsServiceAdmin = fun id -> stub true
         IsUnitManager = fun netid id -> stub true
         IsUnitToolManager = fun netid id -> stub true

--- a/functions/Jwt.fs
+++ b/functions/Jwt.fs
@@ -61,13 +61,12 @@ module Jwt =
         rp
 
     let importPublicKey pem =
-
         let pr =  PemReader(new StringReader(pem));
         let publicKey = pr.ReadObject() :?> Org.BouncyCastle.Crypto.AsymmetricKeyParameter
         let rsaParams = publicKey :?> RsaKeyParameters |> ToRSAParameters
         let csp = new RSACryptoServiceProvider();// cspParams);
         csp.ImportParameters(rsaParams);
-        csp;
+        csp
 
 
     let MissingAuthHeader = "Authorization header is required in the form of 'Bearer <token>'."
@@ -97,7 +96,8 @@ module Jwt =
         try 
             let rsa = importPublicKey uaaPublicKey
             Jose.JWT.Decode<UaaJwt>(jwt, rsa, JwsAlgorithm.RS256) |> ok
-        with _ -> error (Status.Unauthorized, "Access token is not valid.")
+        with _ -> 
+            error (Status.Unauthorized, "Access token is not valid.")
 
     let ensureJwtNotExpired uaa =
         let expiration = uaa.exp |> float |> epoch.AddSeconds

--- a/functions/Jwt.fs
+++ b/functions/Jwt.fs
@@ -8,9 +8,11 @@ open Core.Util
 open System
 open System.Collections.Generic
 open System.Net.Http
-open JWT
-open JWT.Algorithms
-open JWT.Builder
+open Jose
+open Org.BouncyCastle.Crypto.Parameters;
+open Org.BouncyCastle.OpenSsl;
+open System.IO
+open System.Security.Cryptography;
 
 module Jwt =
 
@@ -33,72 +35,40 @@ module Jwt =
     let UserNameClaim = "user_name"
     let epoch = DateTime(1970,1,1,0,0,0,0,System.DateTimeKind.Utc)
 
-    /// Create and sign a JWT
-    let encodeAppJwt secret expiration (netId: string, userId: int option) = 
-        try
-            let builder = 
-                JwtBuilder()
-                    .WithAlgorithm(HMACSHA256Algorithm())
-                    .WithSecret(secret)
-                    .ExpirationTime(expiration)
-                    .AddClaim(UserNameClaim, netId)
-            if (userId.IsSome)
-            then builder.AddClaim(UserIdClaim, userId.Value) |> ignore
-            { access_token = builder.Build() } |> Ok |> async.Return
-        with _ -> Error (Status.InternalServerError, "Failed to create access token.") |> async.Return
+    type UaaJwt = {
+        exp: int64
+        user_name: NetId
+    }
 
-    /// Convert the "exp" unix timestamp into a Datetime
-    let decodeExp exp = 
-        exp 
-        |> string 
-        |> System.Double.Parse 
-        |> (fun unixTicks -> epoch.AddSeconds(unixTicks))
+    let ConvertRSAParametersField (n:Org.BouncyCastle.Math.BigInteger) (size:int) =
+        let bs = n.ToByteArrayUnsigned()
+        if (bs.Length = size)
+        then bs
+        else
+            if (bs.Length > size)
+            then ArgumentException("Specified size too small", "size") |> raise
+            else         
+                let padded = Array.create size (byte 0)
+                Array.Copy(bs, 0, padded, size - bs.Length, bs.Length);
+                padded
 
-    /// Decode a JWT from the UAA service
-    let decodeUaaJwt (jwt:JwtResponse) = 
-        try
-            // decode the UAA JWT
-            let decoded = 
-                JwtBuilder()
-                    .Decode<IDictionary<string, obj>>(jwt.access_token)
-            // map the claims to a domain object
-            let claims = {
-                UserId = 0
-                UserName = decoded.[UserNameClaim] |> string
-                Expiration = decoded.[ExpClaim] |> decodeExp
-            }
-            Ok claims |> async.Return
-        with 
-        | :? TokenExpiredException as ex -> 
-            Error (Status.Unauthorized, "Access token has expired") |> async.Return
-        | exn ->
-            Error (Status.Unauthorized, sprintf "Failed to decode access token: %s" (exn.Message)) |> async.Return
+    let ToRSAParameters (rsaKey:RsaKeyParameters) =
+        let mutable rp = RSAParameters()
+        rp.Modulus <- rsaKey.Modulus.ToByteArrayUnsigned()
+        if (rsaKey.IsPrivate)
+        then rp.D <- ConvertRSAParametersField rsaKey.Exponent rp.Modulus.Length
+        else rp.Exponent <- rsaKey.Exponent.ToByteArrayUnsigned()
+        rp
 
-    /// Decode a JWT issued by the Api.Auth.get function.
-    let decodeAppJwt secret jwt =
-        let result = 
-            try
-                // decode and validate the app JWT
-                let decoded = 
-                    JwtBuilder()
-                        .WithSecret(secret)
-                        .MustVerifySignature()
-                        .Decode<IDictionary<string, string>>(jwt)
-                // map the claims to a domain object
-                let claims = {
-                    UserId = decoded.[UserIdClaim] |> Int32.Parse
-                    UserName = decoded.[UserNameClaim] |> string
-                    Expiration = decoded.[ExpClaim] |> decodeExp
-                }
-                Ok claims
-            with 
-            | :? TokenExpiredException as ex -> 
-                Error (Status.Unauthorized, "Access token has expired")
-            | :? SignatureVerificationException as ex -> 
-                Error (Status.Unauthorized, "Access token has invalid signature")
-            | exn ->
-                Error (Status.Unauthorized, sprintf "Failed to decode access token: %s" (exn.Message))       
-        async.Return result
+    let importPublicKey pem =
+
+        let pr =  PemReader(new StringReader(pem));
+        let publicKey = pr.ReadObject() :?> Org.BouncyCastle.Crypto.AsymmetricKeyParameter
+        let rsaParams = publicKey :?> RsaKeyParameters |> ToRSAParameters
+        let csp = new RSACryptoServiceProvider();// cspParams);
+        csp.ImportParameters(rsaParams);
+        csp;
+
 
     let MissingAuthHeader = "Authorization header is required in the form of 'Bearer <token>'."
 
@@ -122,9 +92,26 @@ module Jwt =
             then Error (Status.Unauthorized, MissingAuthHeader)
             else parts.[1] |> Ok
         async.Return result 
+
+    let validateSignature uaaPublicKey jwt =
+        try 
+            let rsa = importPublicKey uaaPublicKey
+            Jose.JWT.Decode<UaaJwt>(jwt, rsa, JwsAlgorithm.RS256) |> ok
+        with _ -> error (Status.Unauthorized, "Access token is not valid.")
+
+    let ensureJwtNotExpired uaa =
+        let expiration = uaa.exp |> float |> epoch.AddSeconds
+        if (expiration < DateTime.UtcNow)
+        then error(Status.Unauthorized, "Access token has expired.")
+        else ok uaa.user_name
+
+    /// Decode a JWT issued by the Api.Auth.get function.
+    let decodeJwt uaaPublicKey =
+        validateSignature uaaPublicKey
+        >=> ensureJwtNotExpired
                
     /// Attempt to decode the app JWT claims
-    let authenticateRequest (config:AppConfig) = 
+    let authenticateRequest uaaPublicKey = 
         extractAuthHeader 
         >=> extractJwt
-        >=> decodeAppJwt config.JwtSecret
+        >=> decodeJwt uaaPublicKey

--- a/functions/functions.fsproj
+++ b/functions/functions.fsproj
@@ -26,12 +26,13 @@
     <ProjectReference Include="../database/database.fsproj" />    
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.5" />
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
+    <PackageReference Include="jose-jwt" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.KeyPerFile" Version="2.1.1" />
     <PackageReference Include="Dapper" Version="1.50.5" />
     <PackageReference Include="Dapper.SimpleCRUD" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.27" />
-    <PackageReference Include="JWT" Version="4.0.0" />
     <PackageReference Include="Npgsql" Version="4.0.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />


### PR DESCRIPTION
ESI's UAA provides a single-issuer source of JWTs for UITS applications. This allows applications to authenticate users and then make requests of other APIs using that app user's JWT. This change will support scenarios in which e.g. a user authenticates to the UXO Developer Portal, which in turn queries the IT People API for people with certain roles/interests.

The JWT is validated using the UAA Public Key (e.g. https://apps.iu.edu/uaa-prd/oauth/token_key).