### PR TITLE
Delete people from directory when HR record not found

### DIFF
--- a/core/Types.fs
+++ b/core/Types.fs
@@ -306,6 +306,21 @@ type ToolPermission =
     /// For department-scoped tools, the name of the department
     [<Column("department_name")>] DepartmentName: Name }
 
+type HistoricalPersonUnitMetadata =
+  { Unit: string
+    Role: string
+    Title: string
+    Notes: string }
+
+[<CLIMutable>]
+[<Table("historical_people")>]
+type HistoricalPerson =
+  { /// The netid of the removed person
+    [<Column("netid")>] NetId: NetId
+    /// A JSON blob with an array of HistoricalPersonUnitMetadata. 
+    [<Column("metadata")>] Metadata: string
+    /// The name of the tool to which permissions have been granted 
+    [<Column("removed_on")>] RemovedOn: DateTime }
 
 // DOMAIN MODELS
 

--- a/core/Types.fs
+++ b/core/Types.fs
@@ -306,11 +306,14 @@ type ToolPermission =
     /// For department-scoped tools, the name of the department
     [<Column("department_name")>] DepartmentName: Name }
 
+[<CLIMutable>]
 type HistoricalPersonUnitMetadata =
-  { Unit: string
-    Role: string
-    Title: string
-    Notes: string }
+  { [<Column("id")>] Id: Id
+    [<Column("unit")>] Unit: string
+    [<Column("role")>] Role: Role
+    [<Column("permissions")>] UnitPermissions: UnitPermissions
+    [<Column("title")>] Title: string
+    [<Column("notes")>] Notes: string }
 
 [<CLIMutable>]
 [<Table("historical_people")>]

--- a/core/Types.fs
+++ b/core/Types.fs
@@ -310,8 +310,9 @@ type ToolPermission =
 type HistoricalPersonUnitMetadata =
   { [<Column("id")>] Id: Id
     [<Column("unit")>] Unit: string
+    [<Column("hr_department")>] HrDepartment: string
     [<Column("role")>] Role: Role
-    [<Column("permissions")>] UnitPermissions: UnitPermissions
+    [<Column("permissions")>] Permissions: UnitPermissions
     [<Column("title")>] Title: string
     [<Column("notes")>] Notes: string }
 

--- a/database/Migrations/09_AddHistoricalPeopleTable.fs
+++ b/database/Migrations/09_AddHistoricalPeopleTable.fs
@@ -1,0 +1,22 @@
+
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
+namespace Migrations
+open SimpleMigrations
+
+[<Migration(9L, "Add Historical People table")>]
+type AddHistoricalPeopleTable() =
+  inherit Migration()
+  override __.Up() =
+    base.Execute("""
+    CREATE TABLE historical_people (
+      netid TEXT NOT NULL,
+      metadata JSON NOT NULL,
+      removed_on timestamp without time zone
+    );""")
+
+  override __.Down() =
+    base.Execute("""
+    DROP TABLE IF EXISTS historical_people CASCADE;
+""")

--- a/functions/DatabaseRepository.fs
+++ b/functions/DatabaseRepository.fs
@@ -293,7 +293,7 @@ module DatabaseRepository =
         return result
     }
 
-    let insertPerson connStr person =
+    let insertPerson connStr (person:Person) =
         queryDepartments connStr (Some(person.Notes))
         >>= fun results -> 
                 if Seq.isEmpty results

--- a/functions/Validation.fs
+++ b/functions/Validation.fs
@@ -47,7 +47,7 @@ module Validation =
         | None -> Ok m |> async.Return
     let membershipIsUnique data (m:UnitMember) = 
         let entities id = fun () -> data.People.GetMemberships id
-        let conflictPredicate mx = 
+        let conflictPredicate (mx:UnitMember) = 
             (m.Id = 0 || m.Id <> mx.Id)
             && m.UnitId = mx.UnitId 
             && m.PersonId = mx.PersonId

--- a/tasks/Functions.fs
+++ b/tasks/Functions.fs
@@ -214,7 +214,7 @@ module Functions=
     // canonical HR data.
     [<FunctionName("PeopleUpdateBatcher")>]
     let peopleUpdateBatcher
-        ([<TimerTrigger("0 0 14 * * *", RunOnStartup=true)>] timer: TimerInfo,
+        ([<TimerTrigger("0 0 14 * * *")>] timer: TimerInfo,
          [<Queue("people-update")>] queue: ICollector<string>,
          log: ILogger) = 
         

--- a/tasks/Functions.fs
+++ b/tasks/Functions.fs
@@ -278,7 +278,6 @@ module Functions=
         >> Seq.iter queue.Add
 
         // Enqueue the tools for which permissions need to be updated.
-    [<Disable>]
     [<FunctionName("ToolUpdateBatcher")>]
     let toolUpdateBatcher
         ([<TimerTrigger("0 */15 * * * *")>] timer: TimerInfo,
@@ -303,7 +302,6 @@ module Functions=
     // all the people currently in the AD group associated with this tool. 
     // Determine which people should be added/removed from that AD group
     // and enqueue and add/remove message for each.
-    [<Disable>]
     [<FunctionName("ToolUpdateWorker")>]
     let toolUpdateWorker
         ([<QueueTrigger("tool-update")>] item: string,

--- a/tasks/Functions.fs
+++ b/tasks/Functions.fs
@@ -135,6 +135,9 @@ module DataRepository =
 
     let insertHistoricalPersonAndDeletePerson connStr netid metadata = 
         let sql = """
+            -- begin a transaction to log the historical person and 
+            --   delete all person records as an atomic operation
+            BEGIN;
             -- add a row to the historical_people table
             INSERT INTO historical_people (netid, metadata, removed_on)
             VALUES (@NetId, CAST(@Metadata as json), @RemovedOn);
@@ -153,6 +156,8 @@ module DataRepository =
                 WHERE p.netid = @NetId);
             -- delete person record
             DELETE FROM people WHERE netid = @NetId;
+            -- commit the transaction (rolling back changes if anything fails.)
+            COMMIT;
             -- return the netid of the deleted person
             SELECT @NetId;"""
         let json = JsonConvert.SerializeObject(metadata, Core.Json.JsonSettings)

--- a/tasks/Functions.fs
+++ b/tasks/Functions.fs
@@ -121,13 +121,17 @@ module DataRepository =
                 let msg = sprintf "Group modification failed for %A:\n%A" update exn
                 error(Status.InternalServerError, msg)
 
-    let getPersonMemberships connStr netid = 
-        ok Seq.empty<HistoricalPersonUnitMetadata> 
+    let getPersonMemberships connStr netid =
+        let sql = """
+            SELECT u.id, u.name, um.title, um.role, um.permissions, '' as notes
+            FROM people p
+            JOIN unit_members um ON p.id = um.person_id
+            JOIN units u ON u.id = um.unit_id
+            where p.netid = @NetId"""
+        let param = {NetId=netid}
+        fetch connStr (fun cn -> cn.QueryAsync<HistoricalPersonUnitMetadata>(sql, param))
 
-    let insertHistoricalPerson connStr netid metadata = 
-        ok netid
-
-    let deletePerson connStr netid = 
+    let insertHistoricalPersonAndDeletePerson connStr netid metadata = 
         ok netid
 
     let Repository connStr sharedSecret adUser adPassword =

--- a/tasks/tasks.fsproj
+++ b/tasks/tasks.fsproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.27" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="2.3.8" />
     <PackageReference Include="Dapper" Version="1.50.5" />
     <PackageReference Include="Dapper.SimpleCRUD" Version="2.0.0" />


### PR DESCRIPTION
We have a scheduled task that once daily refreshes our `people` records from canonical HR data. If a person has left IU, no HR data will be available for them. When this happens:

0. Delete all `people`, `unit_member` and `unit_member_tools` records for that person.
1. Log the person's removal from the directory, along with any historical unit memberships/roles/permissions in a new table, `historical_people`