### PR TITLE
Add unit member notes

### DIFF
--- a/core/Fakes.fs
+++ b/core/Fakes.fs
@@ -106,6 +106,7 @@ let knopeMembershipRequest:UnitMemberRequest = {
     Permissions=UnitPermissions.Viewer
     Title="Deputy Director"
     Percentage=100
+    Notes=""
 }
 
 let swansonMembership:UnitMember = {
@@ -120,6 +121,7 @@ let swansonMembership:UnitMember = {
     Permissions=UnitPermissions.Owner
     Percentage=100
     MemberTools=[ memberTool ]
+    Notes=""
 }
 
 let knopeMembership = {
@@ -134,6 +136,7 @@ let knopeMembership = {
     Person=Some(knope)
     Unit=parksAndRec
     MemberTools=Seq.empty
+    Notes="Owner of server PA-Parks-Web"
 }
 
 let parksAndRecVacancy = {
@@ -148,6 +151,7 @@ let parksAndRecVacancy = {
     Person=None
     Unit=parksAndRec
     MemberTools=Seq.empty
+    Notes=""
 }
 
 let wyattMembership:UnitMember = {
@@ -162,6 +166,7 @@ let wyattMembership:UnitMember = {
     Permissions=UnitPermissions.Owner
     Percentage=100
     MemberTools=Seq.empty
+    Notes=""
 }
 
 let supportRelationshipRequest:SupportRelationshipRequest = {

--- a/core/Types.fs
+++ b/core/Types.fs
@@ -266,6 +266,9 @@ type UnitMember =
     /// The percentage of time allocated to this position by this person (in case of split appointments).
     [<DefaultValue(100)>]
     [<Column("percentage")>] Percentage: int
+    /// Notes about this person (for admins/reporting eyes only.)
+    [<DefaultValue("")>]
+    [<Column("notes")>] Notes: string
     /// The netid of the person related to this membership.
     [<ReadOnly(true)>][<Column("netid")>] NetId: NetId option
     /// The person related to this membership.
@@ -295,7 +298,10 @@ type UnitMemberRequest =
     Title: string
     /// The percentage of time allocated to this position by this person (in case of split appointments).
     [<DefaultValue(100)>]
-    Percentage: int }
+    Percentage: int 
+    /// Ad-hoc notes about this person's relationship to the unit, to be used by unit managers.
+    [<DefaultValue("")>]
+    Notes: string }
 
 [<CLIMutable>]
 type ToolPermission = 

--- a/core/Types.fs
+++ b/core/Types.fs
@@ -360,13 +360,17 @@ type PeopleRepository = {
     GetMemberships: PersonId -> Async<Result<UnitMember seq,Error>>
 }
 
+type UnitMemberRecordFieldOptions = 
+    | MembersWithoutNotes of Unit
+    | MembersWithNotes of Unit
+
 type UnitRepository = {
     /// Get a list of all units
     GetAll: Filter option -> Async<Result<Unit seq,Error>>
     /// Get a single unit by ID
     Get: Id -> Async<Result<Unit,Error>>
-    /// Get a unit's members by unit ID        
-    GetMembers: Unit -> Async<Result<UnitMember seq,Error>>
+    /// Get a unit's members by unit ID 
+    GetMembers: UnitMemberRecordFieldOptions -> Async<Result<UnitMember seq,Error>>
     /// Get a unit's supported departments by unit ID        
     GetSupportedDepartments: Unit -> Async<Result<SupportRelationship seq,Error>>
     // Get a unit's child units by parent unit Id

--- a/database/Migrations/10_AddNotesFieldToUnitMembersTable.fs
+++ b/database/Migrations/10_AddNotesFieldToUnitMembersTable.fs
@@ -15,5 +15,5 @@ type AddNotesFieldToUnitMembersTable() =
 
   override __.Down() =
     base.Execute("""
-    ALTER TABLE unit_members DROP COLUMN ad_path;
+    ALTER TABLE unit_members DROP COLUMN notes;
 """)

--- a/database/Migrations/10_AddNotesFieldToUnitMembersTable.fs
+++ b/database/Migrations/10_AddNotesFieldToUnitMembersTable.fs
@@ -1,0 +1,19 @@
+
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
+namespace Migrations
+open SimpleMigrations
+
+[<Migration(10L, "Add Notes field to Unit Members table")>]
+type AddNotesFieldToUnitMembersTable() =
+  inherit Migration()
+  override __.Up() =
+    base.Execute("""
+    ALTER TABLE unit_members ADD COLUMN notes TEXT NOT NULL DEFAULT '';
+""")
+
+  override __.Down() =
+    base.Execute("""
+    ALTER TABLE unit_members DROP COLUMN ad_path;
+""")

--- a/functions.tests.integration/DatabaseTests.fs
+++ b/functions.tests.integration/DatabaseTests.fs
@@ -72,14 +72,35 @@ module DatabaseTests=
             actual |> should contain fourthFloor
         
         [<Fact>]
-        member __.``Get members`` () = 
-            let actual = repo.Units.GetMembers parksAndRec |> awaitAndUnpack
+        member __.``Get members with notes`` () = 
+
+            let actual = 
+                parksAndRec
+                |> MembersWithNotes 
+                |> repo.Units.GetMembers  
+                |> awaitAndUnpack
 
             actual |> Seq.length |> should equal 3
+
             let ids = actual |> Seq.map (fun a -> a.Id)
             ids |> should contain swansonMembership.Id
             ids |> should contain knopeMembership.Id
             ids |> should contain parksAndRecVacancy.Id
+
+            let knope = actual |> Seq.find (fun a -> a.Id = knopeMembership.Id)
+            knope.Notes = knopeMembership.Notes
+
+        [<Fact>]
+        member __.``Get members without notes`` () = 
+
+            let actual = 
+                parksAndRec
+                |> MembersWithoutNotes
+                |> repo.Units.GetMembers  
+                |> awaitAndUnpack
+
+            actual |> Seq.length |> should equal 3
+            actual |> Seq.forall (fun a -> a.Notes = "")
 
         [<Fact>]
         member __.``Get children`` () = 


### PR DESCRIPTION
Unit managers often need to record ad-hoc information about unit members. This PR adds a 'notes' field to the unit member. Due to the potential sensitivity of the information this field is only readable/writeable by people who have permissions to manage the unit membership.