### PR TITLE
Maintain a 'shadow' table of HR data.

### DIFF
--- a/core/Fakes.fs
+++ b/core/Fakes.fs
@@ -87,6 +87,17 @@ let admin = {
     IsServiceAdmin=true
 }
 
+let donnaHr:HrPerson = {
+    Id=1
+    NetId="dmeagle"
+    Name="Meagle, Donna"
+    Position="Office Manager"
+    Campus=""
+    CampusPhone=""
+    CampusEmail="dmeagle@pawnee.in.us"
+    HrDepartment="PA-PARKS"
+}
+
 let tool: Tool = 
   { Id=1
     Name="Hammer"
@@ -102,6 +113,7 @@ let memberTool:MemberTool =
 let knopeMembershipRequest:UnitMemberRequest = {
     UnitId=parksAndRec.Id
     PersonId=Some(knope.Id)
+    NetId=None
     Role=Role.Sublead
     Permissions=UnitPermissions.Viewer
     Title="Deputy Director"

--- a/core/Types.fs
+++ b/core/Types.fs
@@ -48,8 +48,7 @@ type AppConfig =
     OAuth2RedirectUrl: string
     DbConnectionString: string
     UseFakes: bool
-    CorsHosts: string
-    SharedSecret: string }
+    CorsHosts: string }
 
 type Role =
     /// This person has an ancillary relationship to this unit. This can apply to administrative assistants or self-supporting faculty.
@@ -488,11 +487,6 @@ type SupportRelationshipRepository = {
     Delete : SupportRelationship -> Async<Result<unit,Error>>
 }
 
-type HrDataRepository = {
-    /// Get a list of all people from a canonical source
-    GetAllPeople: Filter option -> Async<Result<Person seq,Error>>
-}
-
 type AuthorizationRepository = {
     /// Given an OAuth token_key URL and return the public key.
     UaaPublicKey: string -> Async<Result<string,Error>>
@@ -510,7 +504,6 @@ type DataRepository = {
     MemberTools: MemberToolsRepository
     Tools: ToolsRepository
     SupportRelationships: SupportRelationshipRepository
-    Hr: HrDataRepository
     Authorization: AuthorizationRepository
 }
 

--- a/core/Types.fs
+++ b/core/Types.fs
@@ -117,6 +117,27 @@ type Department =
 
 /// A person doing or supporting IT work
 [<CLIMutable>]
+[<Table("hr_people")>]
+type HrPerson = 
+  { /// The unique ID of this person record.
+    [<Key>][<Column("id")>] Id: Id
+    /// The net id (username) of this person.
+    [<Column("netid")>] NetId: NetId
+    /// The preferred name of this person.
+    [<Column("name")>] Name: Name
+    /// The job position of this person as defined by HR. This may be different than the person's title in relation to an IT unit.
+    [<Column("position")>] Position: string
+    /// The primary campus with which this person is affiliated.
+    [<Column("campus")>] Campus: string
+    /// The campus phone number of this person.
+    [<Column("campus_phone")>] CampusPhone: string
+    /// The campus (work) email address of this person.
+    [<Column("campus_email")>] CampusEmail: string 
+    /// Administrative notes about this person, visible only to IT Admins.
+    [<Column("hr_department")>] HrDepartment: string }
+
+/// A person doing or supporting IT work
+[<CLIMutable>]
 [<Table("people")>]
 type Person = 
   { /// The unique ID of this person record.

--- a/core/Types.fs
+++ b/core/Types.fs
@@ -314,6 +314,9 @@ type UnitMemberRequest =
     /// The ID of the person record. This can be null if the position is vacant.
     [<DefaultValue(null)>]
     PersonId: PersonId option
+    /// The NetId of the person, if they are not already in the IT people directory. This can be null if the position is vacant.
+    [<DefaultValue(null)>]
+    NetId: NetId option
     /// The title/position of this membership.
     [<DefaultValue("")>]
     Title: string
@@ -373,8 +376,12 @@ type PeopleRepository = {
     TryGetId: NetId -> Async<Result<NetId * Id option,Error>>
     /// Get a list of all people
     GetAll: PeopleQuery -> Async<Result<Person seq,Error>>
+    /// Get a unioned list of IT and HR people, filtered by name/netid
+    GetAllWithHr: NetId -> Async<Result<Person seq,Error>>
     /// Get a single person by ID
     Get: PersonId -> Async<Result<Person,Error>>
+    /// Get a single HR person by NetId
+    GetHr: NetId -> Async<Result<Person,Error>>
     /// Create a person from canonical HR data
     Create: Person -> Async<Result<Person,Error>>
     /// Get a list of a person's unit memberships

--- a/database/Command.fs
+++ b/database/Command.fs
@@ -154,6 +154,14 @@ module Command =
         with exn -> return handleDbExn "execute" "" exn
     }
 
+    let executeRaw connStr (fn:Cn->unit) = async {
+        try
+            use cn = new NpgsqlConnection(connStr)
+            fn cn
+            return () |> Ok
+        with exn -> return handleDbExn "executeRaw" "" exn
+    }
+
     let init() = 
         SimpleCRUD.SetDialect(SimpleCRUD.Dialect.PostgreSQL)
         Dapper.DefaultTypeMap.MatchNamesWithUnderscores <- true

--- a/database/Fakes.fs
+++ b/database/Fakes.fs
@@ -42,6 +42,7 @@ module Fakes =
         db.Insert<Person>(knope) |> ignore
         db.Insert<Person>(wyatt) |> ignore
         db.Insert<Person>(admin) |> ignore
+        db.Insert<HrPerson>(donnaHr) |> ignore
         // unit membership
         db.Insert<UnitMember>(swansonMembership) |> ignore
         db.Insert<UnitMember>(knopeMembership) |> ignore

--- a/database/Migrations/11_CreateHrPeopleTable.fs
+++ b/database/Migrations/11_CreateHrPeopleTable.fs
@@ -1,0 +1,27 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
+namespace Migrations
+open SimpleMigrations
+
+[<Migration(11L, "Create HR People Table")>]
+type CreateHrPeopleTable() =
+  inherit Migration()
+  override __.Up() =
+    base.Execute("""
+    CREATE TABLE hr_people (
+      id SERIAL NOT NULL,
+      netid TEXT NOT NULL UNIQUE,
+      name TEXT NOT NULL,
+      position TEXT NULL,
+      campus TEXT NOT NULL,
+      campus_phone TEXT NULL,
+      campus_email TEXT NULL,
+      hr_department TEXT NOT NULL,
+      PRIMARY KEY (id)
+    );""")
+
+  override __.Down() =
+    base.Execute("""
+    DROP TABLE IF EXISTS hr_people CASCADE;
+    """)

--- a/database/Program.fs
+++ b/database/Program.fs
@@ -8,7 +8,7 @@ module Program =
     open Migration
 
     let usage () =             
-        printf """Usage : dotnet database.dll '<conn>' <args>
+        printf """Usage : dotnet run '<conn>' <args>
 
   <conn>: the Postgres database connection string
   <args>: SimpleMigration args (try 'help')"""

--- a/functions.tests.integration/DatabaseTests.fs
+++ b/functions.tests.integration/DatabaseTests.fs
@@ -44,7 +44,7 @@ module DatabaseTests=
 
     type UnitsRead(output: ITestOutputHelper)=
         inherit DatabaseIntegrationTestBase()
-        let repo = Repository(testConnectionString, "")
+        let repo = Repository(testConnectionString)
 
         [<Fact>]
         member __.``Units have non-zero IDs`` () =
@@ -119,7 +119,7 @@ module DatabaseTests=
 
     type UnitsWrite(output: ITestOutputHelper)=
         inherit DatabaseIntegrationTestBase()
-        let repo = Repository(testConnectionString, "")
+        let repo = Repository(testConnectionString)
 
         [<Fact>]
         member __.``Create`` () = 

--- a/functions.tests.unit/TestFakes.fs
+++ b/functions.tests.unit/TestFakes.fs
@@ -24,13 +24,11 @@ module TestFakes =
         let req = new HttpRequestMessage()
         req
 
-    let appConfig = {
-        OAuth2ClientId="client id"
+    let appConfig = 
+      { OAuth2ClientId="client id"
         OAuth2ClientSecret="client secret"
         OAuth2TokenUrl="token url"
         OAuth2RedirectUrl="redirect url"
         DbConnectionString="db connectionString"
         UseFakes=false
-        CorsHosts="*"
-        SharedSecret="shared secret"
-    }
+        CorsHosts="*" }

--- a/functions/Api.fs
+++ b/functions/Api.fs
@@ -50,7 +50,6 @@ let getConfiguration () =
         DbConnectionString = getRequiredValue<string> config "DbConnectionString"
         UseFakes = getValueOrDefault<bool> config "UseFakeData" false
         CorsHosts = getValueOrDefault<string> config "CorsHosts" "*"
-        SharedSecret = getRequiredValue<string> config "SharedSecret"
     }
 
 /// HTTP REQUEST

--- a/functions/DatabaseRepository.fs
+++ b/functions/DatabaseRepository.fs
@@ -453,19 +453,6 @@ module DatabaseRepository =
         queryMembership connStr memberTool.MembershipId
         >>= fun membership -> ok (memberTool, membership)
    
-    // *********************
-    // HR Lookups
-    // *********************
-
-    let lookupCanonicalHrPeople sharedSecret (query:NetId option) =
-        match query with
-        | None -> Ok Seq.empty<Person> |> ar
-        | Some(q) ->
-            let url = sprintf "https://itpeople-adapter.apps.iu.edu/people/%s" q
-            let msg = new HttpRequestMessage(HttpMethod.Get, url)
-            msg.Headers.Authorization <-  AuthenticationHeaderValue("Bearer", sharedSecret)
-            sendAsync<seq<Person>> msg
-
     let isServiceAdminSql = """
     SELECT EXISTS (
         SELECT id 
@@ -639,10 +626,6 @@ module DatabaseRepository =
         Delete = deleteSupportRelationship connStr
     }
 
-    let HrRepository(sharedSecret) = {
-        GetAllPeople = lookupCanonicalHrPeople sharedSecret
-    }
-
     let AuthorizationRepository(connStr) = {
         UaaPublicKey = uaaPublicKey
         IsServiceAdmin = isServiceAdmin connStr
@@ -651,7 +634,7 @@ module DatabaseRepository =
         CanModifyPerson = canModifyPerson connStr
     }
 
-    let Repository(connStr, sharedSecret) = {
+    let Repository(connStr) = {
         People = People(connStr)
         Departments = Departments(connStr)
         Units = Units(connStr)
@@ -659,6 +642,5 @@ module DatabaseRepository =
         MemberTools = MemberToolsRepository(connStr)
         Tools = ToolsRepository(connStr)
         SupportRelationships = SupportRelationshipsRepository(connStr)
-        Hr = HrRepository(sharedSecret)
         Authorization = AuthorizationRepository(connStr)
     }

--- a/functions/DatabaseRepository.fs
+++ b/functions/DatabaseRepository.fs
@@ -260,7 +260,7 @@ module DatabaseRepository =
         SELECT p.*, d.*
         FROM people p
         JOIN departments d on d.id = p.department_id
-        JOIN unit_members um on um.person_id = p.id"""
+        LEFT JOIN unit_members um on um.person_id = p.id"""
 
     let mapPeople filter (cn:Cn) = 
         let (query, param) = parseQueryAndParam queryPersonSql filter
@@ -290,8 +290,57 @@ module DatabaseRepository =
             ORDER BY p.netid"""
         fetchAll connStr (mapPeople(WhereParam(whereClause, param)))
 
+    let queryPeopleWithHr connStr netId =
+        let sql = """
+        SELECT
+        	COALESCE(p.netid, hr.netid) as netid, 
+        	COALESCE(p.name, hr.name) as name, 
+        	COALESCE(p.position, hr.position) as position,
+        	COALESCE(p.campus, hr.campus) as campus,
+        	COALESCE(p.campus_phone, hr.campus_phone) as campus_phone,
+        	COALESCE(p.campus_email, hr.campus_email) as campus_email,
+        	COALESCE(p.expertise, '') as expertise,
+        	COALESCE(p.responsibilities, 0) as responsibilities,
+        	COALESCE(p.is_service_admin, false) as is_service_admin,
+        	COALESCE(p.location, '') as location,
+        	COALESCE(p.photo_url, '') as photo_url,
+        	COALESCE(p.notes, '') as notes
+        FROM people p
+        FULL OUTER JOIN hr_people hr using (netid)
+        WHERE COALESCE(p.netid, hr.netid) ILIKE @NetId
+           OR COALESCE(p.name, hr.name) ILIKE @NetId"""
+        let param = {NetId=like netId}
+        fetchAll connStr (fun cn -> cn.QueryAsync<Person>(sql, param))
+
     let queryPerson connStr id =
         fetchOne<Person> connStr mapPerson id
+
+    let queryHrPerson connStr netId =
+        let sql = """
+        SELECT 
+            0 as id,
+            hr.netid, 
+            hr.name, 
+            COALESCE(hr.position, '') as position,
+            hr.campus, 
+            COALESCE(hr.campus_phone, '') as campus_phone,
+            COALESCE(hr.campus_email, '') as campus_email,
+            false as is_service_admin,
+            0 as responsibiliies,
+            '' as location,
+            '' as photo_url,
+            '' as expertise,
+            '' as notes,
+            d.id as department_id 
+        FROM hr_people hr 
+        LEFT JOIN departments d on d.name = hr.hr_department
+        WHERE netid ILIKE @NetId"""
+        let param = {NetId=netId}
+        fetchAll connStr (fun cn -> cn.QueryAsync<Person>(sql, param))
+        >>= fun people ->
+            match people with 
+            | EmptySeq -> error(Status.NotFound, "No HR person was found with that netid")
+            | _ -> people |> Seq.head |> ok
 
     let queryPersonByNetId connStr netId = async {
         let! people = fetchAll<Person> connStr (mapPeople(WhereParam("netid = @NetId", {NetId=netId})))
@@ -306,13 +355,9 @@ module DatabaseRepository =
     }
 
     let insertPerson connStr (person:Person) =
-        queryDepartments connStr (Some(person.Notes))
-        >>= fun results -> 
-                if Seq.isEmpty results
-                then Error(Status.BadRequest, (sprintf "This person's department, '%s', is not known to the IT People directory." person.Notes)) |> ar
-                else results |> Seq.head |> Ok |> ar
-        >>= fun d -> { person with Notes=""; DepartmentId=d.Id } |> Ok |> ar
-        >>= insert<Person> connStr mapPerson
+        if isNull (box person.DepartmentId)
+        then error(Status.BadRequest, "This person's department is not known to the IT People directory.")
+        else insert<Person> connStr mapPerson person
 
     let queryPersonMemberships connStr id =
         fetchAll connStr (mapUnitMembers(WhereId("p.id", id)))
@@ -474,7 +519,9 @@ module DatabaseRepository =
     let People(connStr) = {
         TryGetId = queryPersonByNetId connStr
         GetAll = queryPeople connStr
+        GetAllWithHr = queryPeopleWithHr connStr
         Get = queryPerson connStr
+        GetHr = queryHrPerson connStr
         Create = insertPerson connStr
         GetMemberships = queryPersonMemberships connStr
     }

--- a/functions/FakesRepository.fs
+++ b/functions/FakesRepository.fs
@@ -71,9 +71,6 @@ module FakesRepository =
         Update = fun req -> stub supportRelationship
         Delete = fun id -> stub ()
     }
-    let FakeHr = {
-        GetAllPeople = fun query -> stub ([ swanson ] |> List.toSeq)
-    }
 
     let FakeAuthorization : AuthorizationRepository = {
         UaaPublicKey = fun _ -> stub adminJwt.access_token
@@ -91,7 +88,6 @@ module FakesRepository =
         MemberTools = FakeMemberToolsRepository
         Tools = FakeToolsRepository
         SupportRelationships = FakeSupportRelationships
-        Hr = FakeHr
         Authorization = FakeAuthorization
     }
 

--- a/functions/FakesRepository.fs
+++ b/functions/FakesRepository.fs
@@ -13,7 +13,9 @@ module FakesRepository =
     let FakePeople = {
         TryGetId = fun netId -> stub (swanson.NetId, Some(swanson.Id))
         GetAll = fun query -> stub ([ swanson ] |> List.toSeq)
+        GetAllWithHr = fun query -> stub ([ swanson ] |> List.toSeq)
         Get = fun id -> stub swanson
+        GetHr = fun netid -> stub swanson
         Create = fun person -> stub swanson
         GetMemberships = fun personId -> stub ([ swansonMembership ] |> List.toSeq)
     }

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -37,7 +37,7 @@ module Functions =
         then FakesRepository.Repository
         else
             Database.Command.init()
-            DatabaseRepository.Repository(config.DbConnectionString, config.SharedSecret)
+            DatabaseRepository.Repository(config.DbConnectionString)
     let log = createLogger config.DbConnectionString
     
     let publicKey =

--- a/tasks/Functions.fs
+++ b/tasks/Functions.fs
@@ -289,7 +289,7 @@ module Functions=
     // canonical HR data.
     [<FunctionName("PeopleUpdateHrTable")>]
     let peopleUpdateHrTable
-        ([<TimerTrigger("0 00 14 * * 1-5", RunOnStartup=true)>] timer: TimerInfo,
+        ([<TimerTrigger("0 00 14 * * 1-5")>] timer: TimerInfo,
          [<Queue("people-update-batch")>] queue: ICollector<string>,
          log: ILogger) = 
 

--- a/tasks/Functions.fs
+++ b/tasks/Functions.fs
@@ -275,10 +275,16 @@ module Functions=
          log: ILogger) = 
 
         let enqueueBatchUpdate () = 
-            queue.Add ("go!")
+            queue.Add ("go go gadget update directory people!")
+
+        let skipIfIsPastDue () =
+            if timer.IsPastDue
+            then error(Status.BadRequest, "Due to DSS1PRD availability, only run this function at the scheduled time.")
+            else ok ()
 
         let workflow = 
-            data.FetchAllHrPeople
+            skipIfIsPastDue
+            >=> data.FetchAllHrPeople
             >=> data.UpdateHrPeople
             >=> tap enqueueBatchUpdate
 

--- a/tasks/Functions.fs
+++ b/tasks/Functions.fs
@@ -280,7 +280,7 @@ module Functions=
     // canonical HR data.
     [<FunctionName("PeopleUpdateBatcher")>]
     let peopleUpdateBatcher
-        ([<TimerTrigger("0 0 14 * * *")>] timer: TimerInfo,
+        ([<TimerTrigger("0 0 14 * * 1-5")>] timer: TimerInfo,
          [<Queue("people-update")>] queue: ICollector<string>,
          log: ILogger) = 
         

--- a/tasks/Functions.fs
+++ b/tasks/Functions.fs
@@ -153,6 +153,7 @@ module DataRepository =
         LdapAttribute("member", value)
 
     let doLdapAction adUser adsPassword action = 
+            let adUser = sprintf """ads\%s""" adUser
             use ldap = new LdapConnection()
             ldap.Connect("ads.iu.edu", 389)
             ldap.Bind(adUser, adsPassword)  

--- a/tasks/Functions.fs
+++ b/tasks/Functions.fs
@@ -52,6 +52,7 @@ module DataRepository =
             FROM DSS.HRS_IT_JOB_CUR_GT
             WHERE
                 PRSN_USER_ID IS NOT NULL
+                AND POS_DESC IS NOT NULL
                 AND JOB_PRM_2ND_IND = 'P'
             ORDER BY PRSN_UNIV_ID"""
         try
@@ -84,12 +85,13 @@ module DataRepository =
 
     let updatePerson connStr (person:HrPerson) = 
         let sql = """
-            UPDATE people 
+            UPDATE people
             SET name = @Name,
                 position = @Position,
                 campus = @Campus,
                 campus_phone = @CampusPhone,
-                campus_email = @CampusEmail
+                campus_email = @CampusEmail,
+                department_id = (SELECT id FROM departments WHERE name=@HrDepartment)
             WHERE netid = @NetId
             RETURNING *;"""
         fetch connStr (fun cn -> cn.QuerySingleAsync<Person>(sql, person))

--- a/tasks/tasks.fsproj
+++ b/tasks/tasks.fsproj
@@ -23,6 +23,6 @@
     <PackageReference Include="Dapper" Version="1.50.5" />
     <PackageReference Include="Dapper.SimpleCRUD" Version="2.0.0" />
     <PackageReference Include="Npgsql" Version="4.0.3" />
-
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Keeping canonical HR data 'shadowed' in a local table speeds up two important operations:
1. searches for employees that are not already in the directory; and
2. daily updates of canonical directory data.

This PR creates a new table `hr_people` and a once-daily task `PeopleUpdateHrTable` to populate it. The `PeopleUpdateBatcher` function is subsequently triggered to update each person in the `people` table from their corresponding entry in the `hr_people` table. The `hr_people` table is now used as a secondary data source when search for folks that might not be in the directory.