### PR TITLE
Add legacy endpoints

### DIFF
--- a/core/Fakes.fs
+++ b/core/Fakes.fs
@@ -239,3 +239,8 @@ let lspInfo = {
   IsLA=true
   NetworkID=wyatt.NetId
 }
+
+let lspDepartments = {
+  DeptCodeList={ Values = [|parksDept.Name|] }
+  NetworkID=wyatt.NetId
+}

--- a/core/Fakes.fs
+++ b/core/Fakes.fs
@@ -232,3 +232,10 @@ let buildingRelationship:BuildingRelationship = {
   Unit=cityOfPawnee
   Building=cityHall
 }
+
+// Legacy
+
+let lspInfo = {
+  IsLA=true
+  NetworkID=wyatt.NetId
+}

--- a/core/Fakes.fs
+++ b/core/Fakes.fs
@@ -244,3 +244,13 @@ let lspDepartments = {
   DeptCodeList={ Values = [|parksDept.Name|] }
   NetworkID=wyatt.NetId
 }
+
+let lspContact = { 
+  IsLSPAdmin=true
+  NetworkID=wyatt.NetId 
+  Email=wyatt.CampusEmail
+  FullName=wyatt.Name
+  GroupInternalEmail=""
+  Phone=wyatt.CampusPhone
+  PreferredEmail=wyatt.CampusEmail
+}

--- a/core/Types.fs
+++ b/core/Types.fs
@@ -409,6 +409,22 @@ type HistoricalPerson =
     /// The name of the tool to which permissions have been granted 
     [<Column("removed_on")>] RemovedOn: DateTime }
 
+open System.Xml.Serialization
+
+[<CLIMutable>]
+[<Serializable>]
+type LspInfo =
+  { [<XmlElement("IsLA")>] IsLA: bool
+    [<XmlElement("NetworkID")>] NetworkID: string }
+
+[<CLIMutable>]
+[<Serializable>]
+[<XmlRoot("ArrayOfLspInfo")>]
+type LspInfoArray = {
+  [<XmlElement("LspInfo")>] 
+  LspInfos: LspInfo []
+}
+
 // DOMAIN MODELS
 
 type MessageResult = {
@@ -557,7 +573,6 @@ type BuildingRelationshipRepository = {
     Delete : BuildingRelationship -> Async<Result<unit,Error>>
 }
 
-
 type AuthorizationRepository = {
     /// Given an OAuth token_key URL and return the public key.
     UaaPublicKey: string -> Async<Result<string,Error>>
@@ -565,6 +580,10 @@ type AuthorizationRepository = {
     IsUnitManager: NetId -> Id -> Async<Result<bool, Error>>
     IsUnitToolManager: NetId -> Id -> Async<Result<bool, Error>>
     CanModifyPerson: NetId -> Id -> Async<Result<bool,Error>>
+}
+
+type LegacyRepository = {
+    GetLspList: unit -> Async<Result<LspInfoArray, Error>>
 }
 
 type DataRepository = {
@@ -578,6 +597,7 @@ type DataRepository = {
     SupportRelationships: SupportRelationshipRepository
     BuildingRelationships: BuildingRelationshipRepository
     Authorization: AuthorizationRepository
+    Legacy: LegacyRepository
 }
 
 let stub a = a |> Ok |> async.Return

--- a/core/Types.fs
+++ b/core/Types.fs
@@ -438,6 +438,27 @@ type LspDepartmentArray = {
   [<XmlElement("NetworkID")>] NetworkID: string
 }
 
+[<CLIMutable>]
+[<Serializable>]
+type LspContact =
+  { [<XmlElement("isLspAdmin")>] IsLSPAdmin: bool
+    [<XmlElement("NetworkID")>] NetworkID: string 
+    [<XmlElement("Email")>] Email: string 
+    [<XmlElement("FullName")>] FullName: string 
+    [<XmlElement("GroupInternalEmail")>] GroupInternalEmail: string 
+    [<XmlElement("PreferredEmail")>] PreferredEmail: string 
+    [<XmlElement("Phone")>] Phone: string }
+
+[<CLIMutable>]
+[<Serializable>]
+[<XmlRoot("ArrayOfLspContact")>]
+type LspContactArray = {
+  [<XmlElement("LspContact")>] 
+  LspContacts: LspContact []
+}
+
+
+
 // DOMAIN MODELS
 
 type MessageResult = {
@@ -598,7 +619,7 @@ type AuthorizationRepository = {
 type LegacyRepository = {
     GetLspList: unit -> Async<Result<LspInfoArray, Error>>
     GetLspDepartments: string -> Async<Result<LspDepartmentArray, Error>>
-    
+    GetDepartmentLsps: string -> Async<Result<LspContactArray, Error>>
 }
 
 type DataRepository = {

--- a/core/Types.fs
+++ b/core/Types.fs
@@ -425,6 +425,19 @@ type LspInfoArray = {
   LspInfos: LspInfo []
 }
 
+[<CLIMutable>]
+[<Serializable>]
+type DeptCodeList =
+  { [<XmlElement("a")>] Values: string[] }
+
+[<CLIMutable>]
+[<Serializable>]
+[<XmlRoot("LspDepartment")>]
+type LspDepartmentArray = {
+  [<XmlElement("DeptCodeList")>] DeptCodeList: DeptCodeList
+  [<XmlElement("NetworkID")>] NetworkID: string
+}
+
 // DOMAIN MODELS
 
 type MessageResult = {
@@ -584,6 +597,8 @@ type AuthorizationRepository = {
 
 type LegacyRepository = {
     GetLspList: unit -> Async<Result<LspInfoArray, Error>>
+    GetLspDepartments: string -> Async<Result<LspDepartmentArray, Error>>
+    
 }
 
 type DataRepository = {

--- a/core/Types.fs
+++ b/core/Types.fs
@@ -441,13 +441,13 @@ type LspDepartmentArray = {
 [<CLIMutable>]
 [<Serializable>]
 type LspContact =
-  { [<XmlElement("isLspAdmin")>] IsLSPAdmin: bool
-    [<XmlElement("NetworkID")>] NetworkID: string 
-    [<XmlElement("Email")>] Email: string 
+  { [<XmlElement("Email")>] Email: string 
     [<XmlElement("FullName")>] FullName: string 
     [<XmlElement("GroupInternalEmail")>] GroupInternalEmail: string 
+    [<XmlElement("NetworkID")>] NetworkID: string 
+    [<XmlElement("Phone")>] Phone: string 
     [<XmlElement("PreferredEmail")>] PreferredEmail: string 
-    [<XmlElement("Phone")>] Phone: string }
+    [<XmlElement("isLspAdmin")>] IsLSPAdmin: bool }
 
 [<CLIMutable>]
 [<Serializable>]

--- a/functions.tests.integration/ApiErrorTests.fs
+++ b/functions.tests.integration/ApiErrorTests.fs
@@ -36,18 +36,37 @@ module ApiErrorTests =
         response.StatusCode |> should equal expectedStatus
         response
 
-    let parseContent<'T> (response:HttpResponseMessage) = 
+    let readContent (response:HttpResponseMessage) =
         response.Content.ReadAsStringAsync() 
         |> Async.AwaitTask 
         |> Async.RunSynchronously
+
+    let parseContent<'T> (response:HttpResponseMessage) = 
+        response
+        |> readContent
         |> fun str -> JsonConvert.DeserializeObject<'T>(value=str, settings=JsonSettings)
+
+    let toBytes (x : string) = System.Text.Encoding.ASCII.GetBytes x
+    let parseXmlContent<'T> (response:HttpResponseMessage) = 
+        let xml = response |> readContent
+        let serializer = System.Xml.Serialization.XmlSerializer(typeof<'T>)
+        use stream = new System.IO.MemoryStream(toBytes xml)
+        serializer.Deserialize stream :?> 'T
 
     let shouldGetContent<'T> (expectedContent:'T) (response:HttpResponseMessage) =
         response |> parseContent<'T> |> should equal expectedContent
         response
 
+    let shouldGetXmlContent<'T> (expectedContent:'T) (response:HttpResponseMessage) =
+        response |> parseXmlContent<'T> |> should equal expectedContent
+        response
+
     let evaluateContent<'T> (evalFn:'T -> unit) (response:HttpResponseMessage) =
         response |> parseContent<'T> |> evalFn
+        response    
+
+    let evaluateXmlContent<'T> (evalFn:'T -> unit) (response:HttpResponseMessage) =
+        response |> parseXmlContent<'T> |> evalFn
         response    
 
     let personUpdate = 
@@ -68,147 +87,147 @@ module ApiErrorTests =
     type ApiTests(output: ITestOutputHelper)=
         inherit HttpTestBase(output)
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People search: netid`` () = 
             requestFor HttpMethod.Get "people?q=rswa"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [swanson]
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People search: netid is case insensitive`` () = 
             requestFor HttpMethod.Get "people?q=RSWA"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [swanson]
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People search: name`` () = 
             requestFor HttpMethod.Get "people?q=Ron"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [swanson]
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People search: name is case insensitive`` () = 
             requestFor HttpMethod.Get "people?q=RON"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [swanson]
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People search: single class`` () = 
             requestFor HttpMethod.Get "people?class=ItLeadership"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [knope; swanson]
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People search: class is case insensitive`` () = 
             requestFor HttpMethod.Get "people?class=itleadership"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [knope; swanson]
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People search: multiple classes are unioned`` () = 
             requestFor HttpMethod.Get "people?class=ItLeadership,ItProjectMgt"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [wyatt; knope; swanson;]
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People search: single interest`` () = 
             requestFor HttpMethod.Get "people?interest=waffles"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [knope]
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People search: multiple interests are unioned`` () = 
             requestFor HttpMethod.Get "people?interest=waffles,games"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [wyatt; knope]
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People search: multiple parameters are intersected`` () = 
             requestFor HttpMethod.Get "people?class=ItLeadership&interest=waffles"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [knope]
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People search: handles junk roles`` () = 
             requestFor HttpMethod.Get "people?class=FooBar,ItLeadership"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [knope; swanson]
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People search: handles junk interests`` () = 
             requestFor HttpMethod.Get "people?interest=waffles,foobar"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [knope]
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People search: single role`` () = 
             requestFor HttpMethod.Get "people?role=Leader"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [wyatt; swanson ]
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People search: multiple roles are unioned`` () = 
             requestFor HttpMethod.Get "people?role=Leader,Sublead"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [ wyatt; knope; swanson]
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People search: single campus: Pawnee`` () = 
             requestFor HttpMethod.Get "people?campus=Pawnee"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [ knope; swanson]
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People search: single campus: Indianapolis`` () = 
             requestFor HttpMethod.Get "people?campus=Indianapolis"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [ wyatt; admin ]
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People search: multiple campus: Indianapolis and Pawnee`` () = 
             requestFor HttpMethod.Get "people?campus=Pawnee,Indianapolis"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [ wyatt; admin; knope; swanson;  ]
             
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People search: single permission`` () = 
             requestFor HttpMethod.Get "people?permission=Viewer"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [knope]
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People search: multiple permission are unioned`` () = 
             requestFor HttpMethod.Get "people?permission=Viewer,Owner"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [wyatt; knope; swanson]
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Donna is not in the directory`` () = 
             requestFor HttpMethod.Get "people?q=donna"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent []
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Lookup of Leslie yields directory record`` () = 
             requestFor HttpMethod.Get "people-lookup?q=leslie"
             |> withAuthentication adminJwt
@@ -218,7 +237,7 @@ module ApiErrorTests =
                 let a = people |> Seq.head
                 a.NetId |> should equal knope.NetId)
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Lookup of Donna yields HR record`` () = 
             requestFor HttpMethod.Get "people-lookup?q=donna"
             |> withAuthentication adminJwt
@@ -228,7 +247,7 @@ module ApiErrorTests =
                 let a = people |> Seq.head
                 a.NetId |> should equal donnaHr.NetId)
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Add Donna to Parks unit`` () = 
             requestFor HttpMethod.Post "memberships"
             |> withAuthentication adminJwt
@@ -245,21 +264,21 @@ module ApiErrorTests =
             |> evaluateContent<UnitMember> (fun um -> 
                 um.Person.Value.NetId  |> should equal donnaHr.NetId)
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People: get by id`` () = 
             requestFor HttpMethod.Get (sprintf "people/%d" knope.Id)
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent knope
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People: get by netid`` () = 
             requestFor HttpMethod.Get (sprintf "people/%s" knope.NetId)
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent knope
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People: get memberships by id`` () = 
             requestFor HttpMethod.Get (sprintf "people/%d/memberships" knope.Id)
             |> withAuthentication adminJwt
@@ -269,7 +288,7 @@ module ApiErrorTests =
                  let head = memberships |> Seq.head
                  head.Id |> should equal knopeMembership.Id)
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People: get memberships by netid`` () = 
             requestFor HttpMethod.Get (sprintf "people/%s/memberships" knope.NetId)
             |> withAuthentication adminJwt
@@ -279,7 +298,7 @@ module ApiErrorTests =
                  let head = memberships |> Seq.head
                  head.Id |> should equal knopeMembership.Id)
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People: admin can update any record`` () = 
             requestFor HttpMethod.Put (sprintf "people/%d" knope.Id)
             |> withAuthentication adminJwt
@@ -287,7 +306,7 @@ module ApiErrorTests =
             |> shouldGetResponse HttpStatusCode.OK
             |> evaluateContent<Person> evaluatePersonUpdate
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People: knope can update own record`` () = 
             requestFor HttpMethod.Put (sprintf "people/%d" knope.Id)
             |> withAuthentication knopeJwt
@@ -295,7 +314,7 @@ module ApiErrorTests =
             |> shouldGetResponse HttpStatusCode.OK
             |> evaluateContent<Person> evaluatePersonUpdate
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People: unit owner swanson can update member knope`` () = 
             requestFor HttpMethod.Put (sprintf "people/%d" knope.Id)
             |> withAuthentication swansonJwt
@@ -303,21 +322,21 @@ module ApiErrorTests =
             |> shouldGetResponse HttpStatusCode.OK
             |> evaluateContent<Person> evaluatePersonUpdate
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People: unit member knope can't update owner swanson`` () = 
             requestFor HttpMethod.Put (sprintf "people/%d" swanson.Id)
             |> withAuthentication knopeJwt
             |> withBody personUpdate
             |> shouldGetResponse HttpStatusCode.Forbidden
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People: unit owner swanson can't someone in another unit`` () = 
             requestFor HttpMethod.Put (sprintf "people/%d" wyatt.Id)
             |> withAuthentication swansonJwt
             |> withBody personUpdate
             |> shouldGetResponse HttpStatusCode.Forbidden
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``People: unit owner swanson can update member knope: raw`` () = 
             requestFor HttpMethod.Put (sprintf "people/%d" knope.Id)
             |> withAuthentication swansonJwt
@@ -325,7 +344,7 @@ module ApiErrorTests =
             |> shouldGetResponse HttpStatusCode.OK
             |> evaluateContent<Person> evaluatePersonUpdate
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Buildings: get all`` () = 
             requestFor HttpMethod.Get "buildings"
             |> withAuthentication swansonJwt
@@ -335,7 +354,7 @@ module ApiErrorTests =
                  let head = buildings |> Seq.head
                  head.Id |> should equal cityHall.Id)
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Buildings: get one`` () = 
             requestFor HttpMethod.Get (sprintf "buildings/%d" cityHall.Id)
             |> withAuthentication swansonJwt
@@ -343,7 +362,7 @@ module ApiErrorTests =
             |> evaluateContent<Building> (fun building ->
                  building.Id |> should equal cityHall.Id)
         
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Buildings: search name`` () = 
             requestFor HttpMethod.Get "buildings?q=pawn"
             |> withAuthentication swansonJwt
@@ -353,7 +372,7 @@ module ApiErrorTests =
                  let head = buildings |> Seq.head
                  head.Id |> should equal cityHall.Id)
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Buildings: search address`` () = 
             requestFor HttpMethod.Get "buildings?q=main"
             |> withAuthentication swansonJwt
@@ -363,7 +382,7 @@ module ApiErrorTests =
                  let head = buildings |> Seq.head
                  head.Id |> should equal cityHall.Id)
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Buildings: search code`` () = 
             requestFor HttpMethod.Get "buildings?q=pa123"
             |> withAuthentication swansonJwt
@@ -373,7 +392,7 @@ module ApiErrorTests =
                  let head = buildings |> Seq.head
                  head.Id |> should equal cityHall.Id)
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Buildings: search code with dash`` () = 
             requestFor HttpMethod.Get "buildings?q=pa-123"
             |> withAuthentication swansonJwt
@@ -383,7 +402,7 @@ module ApiErrorTests =
                  let head = buildings |> Seq.head
                  head.Id |> should equal cityHall.Id)
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Building relationships: get all`` () = 
             requestFor HttpMethod.Get "buildingRelationships"
             |> withAuthentication swansonJwt
@@ -393,7 +412,7 @@ module ApiErrorTests =
                  let head = relationships |> Seq.head
                  head.Id |> should equal buildingRelationship.Id)
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Building relationships: get one`` () = 
             requestFor HttpMethod.Get (sprintf "buildingRelationships/%d" buildingRelationship.Id)
             |> withAuthentication swansonJwt
@@ -401,7 +420,7 @@ module ApiErrorTests =
             |> evaluateContent<BuildingRelationship> (fun building ->
                  building.Id |> should equal buildingRelationship.Id)
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Building: get supporting units`` () = 
             requestFor HttpMethod.Get (sprintf "buildings/%d/supportingUnits" cityHall.Id)
             |> withAuthentication swansonJwt
@@ -410,36 +429,46 @@ module ApiErrorTests =
                  relationships |> Seq.length |> should equal 1
                  let head = relationships |> Seq.head
                  head.Id |> should equal buildingRelationship.Id)
+        
+        [<Fact>]       
+        member __.``Legacy: LspList`` () = 
+            requestFor HttpMethod.Get "LspdbWebService.svc/LspList"
+            |> withAuthentication swansonJwt
+            |> shouldGetResponse HttpStatusCode.OK
+            |> evaluateXmlContent<LspInfoArray> (fun arr ->
+                 arr.LspInfos |> Seq.length |> should equal 1
+                 let head = arr.LspInfos |> Seq.head
+                 head |> should equal lspInfo)
 
     type ApiErrorTests(output: ITestOutputHelper)=
         inherit HttpTestBase(output)
 
-        [<Fact>]
+        //[<Fact>]
         member __.``Unauthorized request yields 401 Unauthorized`` () = 
             requestFor HttpMethod.Get "units" 
             |> shouldGetResponse HttpStatusCode.Unauthorized
 
-        [<Theory>]
-        [<InlineDataAttribute("units")>]
-        [<InlineDataAttribute("departments")>]
-        [<InlineDataAttribute("buildings")>]
-        [<InlineDataAttribute("memberships")>]
-        [<InlineDataAttribute("membertools")>]
-        [<InlineDataAttribute("supportRelationships")>]
-        [<InlineDataAttribute("buildingRelationships")>]
-        [<InlineDataAttribute("people")>]
+        //[<Theory>]
+        //[<InlineDataAttribute("units")>]
+        //[<InlineDataAttribute("departments")>]
+        //[<InlineDataAttribute("buildings")>]
+        //[<InlineDataAttribute("memberships")>]
+        //[<InlineDataAttribute("membertools")>]
+        //[<InlineDataAttribute("supportRelationships")>]
+        //[<InlineDataAttribute("buildingRelationships")>]
+        //[<InlineDataAttribute("people")>]
         member __.``Get non-existent resource yields 404 Not Found`` (resource: string) = 
             sprintf "units/%s/1000" resource
             |> requestFor HttpMethod.Get
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        [<Theory>]
-        [<InlineDataAttribute("units")>]
-        [<InlineDataAttribute("memberships")>]
-        [<InlineDataAttribute("membertools")>]
-        [<InlineDataAttribute("supportRelationships")>]
-        [<InlineDataAttribute("buildingRelationships")>]
+        //[<Theory>]
+        //[<InlineDataAttribute("units")>]
+        //[<InlineDataAttribute("memberships")>]
+        //[<InlineDataAttribute("membertools")>]
+        //[<InlineDataAttribute("supportRelationships")>]
+        //[<InlineDataAttribute("buildingRelationships")>]
         member __.``Delete non-existent resource yields 404 Not Found`` (resource: string) = 
             sprintf "units/%s/1000" resource
             |> requestFor HttpMethod.Delete
@@ -447,7 +476,7 @@ module ApiErrorTests =
             |> shouldGetResponse HttpStatusCode.NotFound
 
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Get non-existent person`` () = 
             requestFor HttpMethod.Get "people/foo"
             |> withAuthentication adminJwt
@@ -457,21 +486,21 @@ module ApiErrorTests =
         // Units
         // *********************
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Create a unit with missing required field in request body yields 400 Bad Request`` () = 
             requestFor HttpMethod.Post "units"
             |> withAuthentication adminJwt
             |> withRawBody """{"description":"d", "url":"u", "parentId":undefined}"""
             |> shouldGetResponse HttpStatusCode.BadRequest
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Create a unit with non existent parent yields 404 Not Found`` () = 
             requestFor HttpMethod.Post "units"
             |> withAuthentication adminJwt
             |> withBody { parksAndRec with Name="test"; ParentId = Some(1000) }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Update a unit with circular relationship yields 409 Conflict`` () = 
             sprintf "units/%d" cityOfPawnee.Id
             |> requestFor HttpMethod.Put
@@ -479,7 +508,7 @@ module ApiErrorTests =
             |> withBody { cityOfPawnee with ParentId=Some(parksAndRec.Id) }
             |> shouldGetResponse HttpStatusCode.Conflict
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Delete a unit with children yields 409 Conflict`` () = 
             sprintf "units/%d" cityOfPawnee.Id
             |> requestFor HttpMethod.Delete
@@ -490,28 +519,28 @@ module ApiErrorTests =
         // Unit Memberships
         // *********************
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Create a membership with non existent unit yields 404 Not Found`` () = 
             requestFor HttpMethod.Post "memberships"
             |> withAuthentication adminJwt
             |> withBody { knopeMembership with UnitId=1000 }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Create a membership with non existent person yields 404 Not Found`` () = 
             requestFor HttpMethod.Post "memberships"
             |> withAuthentication adminJwt
             |> withBody { knopeMembership with PersonId=Some(1000) }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Create a membership that duplicates existing memberships yields 409 Conflict`` () = 
             requestFor HttpMethod.Post "memberships"
             |> withAuthentication adminJwt
             |> withBody knopeMembership
             |> shouldGetResponse HttpStatusCode.Conflict
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Update a membership that duplicates existing memberships yields 409 Conflict`` () = 
             sprintf "memberships/%d" swansonMembership.Id
             |> requestFor HttpMethod.Put
@@ -523,21 +552,21 @@ module ApiErrorTests =
         // Support Relationships
         // *********************
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Create a support relationship with non existent unit yields 404 Not Found`` () = 
             requestFor HttpMethod.Post "supportRelationships"
             |> withAuthentication adminJwt
             |> withBody { supportRelationship with UnitId=1000 }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Create a support relationship with non existent department yields 404 Not Found`` () = 
             requestFor HttpMethod.Post "supportRelationships"
             |> withAuthentication adminJwt
             |> withBody { supportRelationship with DepartmentId=1000 }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Create a supportRelationship that duplicates existing relationship yields 409 Conflict`` () = 
             requestFor HttpMethod.Post "supportRelationships"
             |> withAuthentication adminJwt
@@ -548,21 +577,21 @@ module ApiErrorTests =
         // Building Relationships
         // *********************
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Create a building relationship with non existent unit yields 404 Not Found`` () = 
             requestFor HttpMethod.Post "buildingRelationships"
             |> withAuthentication adminJwt
             |> withBody { buildingRelationship with UnitId=1000 }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Create a building relationship with non existent department yields 404 Not Found`` () = 
             requestFor HttpMethod.Post "buildingRelationships"
             |> withAuthentication adminJwt
             |> withBody { buildingRelationship with BuildingId=1000 }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Create a building relationship that duplicates existing relationship yields 409 Conflict`` () = 
             requestFor HttpMethod.Post "buildingRelationships"
             |> withAuthentication adminJwt
@@ -573,35 +602,35 @@ module ApiErrorTests =
         // Member Tools
         // *****************
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Create a member tool with non existent membership yields 404 Not Found`` () = 
             requestFor HttpMethod.Post "membertools"
             |> withAuthentication adminJwt
             |> withBody { memberTool with MembershipId=1000 }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Create a member tool with non existent tool yields 404 Not Found`` () = 
             requestFor HttpMethod.Post "membertools"
             |> withAuthentication adminJwt
             |> withBody { memberTool with ToolId=1000 }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Update a nonexistent member tool yields 404 Not Found`` () = 
             requestFor HttpMethod.Put "membertools/1000"
             |> withAuthentication adminJwt
             |> withBody memberTool
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Update a member tool with non existent membership yields 404 Not Found`` () = 
             requestFor HttpMethod.Put "membertools/1"
             |> withAuthentication adminJwt
             |> withBody { memberTool with MembershipId=1000 }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        [<Fact>]       
+        //[<Fact>]       
         member __.``Update a member tool with non existent tool yields 404 Not Found`` () = 
             requestFor HttpMethod.Put "membertools/1"
             |> withAuthentication adminJwt

--- a/functions.tests.integration/ApiErrorTests.fs
+++ b/functions.tests.integration/ApiErrorTests.fs
@@ -440,6 +440,16 @@ module ApiErrorTests =
                  let head = arr.LspInfos |> Seq.head
                  head |> should equal lspInfo)
 
+        
+        [<Fact>]       
+        member __.``Legacy: LspDepartments`` () = 
+            requestFor HttpMethod.Get (sprintf "LspdbWebService.svc/LspDepartments/%s" wyatt.NetId)
+            |> withAuthentication swansonJwt
+            |> shouldGetResponse HttpStatusCode.OK
+            |> evaluateXmlContent<LspDepartmentArray> (fun arr ->
+                 arr.NetworkID |> should equal wyatt.NetId 
+                 arr.DeptCodeList.Values |> should equal [| parksDept.Name |] )
+
     type ApiErrorTests(output: ITestOutputHelper)=
         inherit HttpTestBase(output)
 

--- a/functions.tests.integration/ApiErrorTests.fs
+++ b/functions.tests.integration/ApiErrorTests.fs
@@ -87,147 +87,147 @@ module ApiErrorTests =
     type ApiTests(output: ITestOutputHelper)=
         inherit HttpTestBase(output)
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People search: netid`` () = 
             requestFor HttpMethod.Get "people?q=rswa"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [swanson]
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People search: netid is case insensitive`` () = 
             requestFor HttpMethod.Get "people?q=RSWA"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [swanson]
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People search: name`` () = 
             requestFor HttpMethod.Get "people?q=Ron"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [swanson]
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People search: name is case insensitive`` () = 
             requestFor HttpMethod.Get "people?q=RON"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [swanson]
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People search: single class`` () = 
             requestFor HttpMethod.Get "people?class=ItLeadership"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [knope; swanson]
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People search: class is case insensitive`` () = 
             requestFor HttpMethod.Get "people?class=itleadership"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [knope; swanson]
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People search: multiple classes are unioned`` () = 
             requestFor HttpMethod.Get "people?class=ItLeadership,ItProjectMgt"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [wyatt; knope; swanson;]
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People search: single interest`` () = 
             requestFor HttpMethod.Get "people?interest=waffles"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [knope]
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People search: multiple interests are unioned`` () = 
             requestFor HttpMethod.Get "people?interest=waffles,games"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [wyatt; knope]
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People search: multiple parameters are intersected`` () = 
             requestFor HttpMethod.Get "people?class=ItLeadership&interest=waffles"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [knope]
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People search: handles junk roles`` () = 
             requestFor HttpMethod.Get "people?class=FooBar,ItLeadership"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [knope; swanson]
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People search: handles junk interests`` () = 
             requestFor HttpMethod.Get "people?interest=waffles,foobar"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [knope]
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People search: single role`` () = 
             requestFor HttpMethod.Get "people?role=Leader"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [wyatt; swanson ]
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People search: multiple roles are unioned`` () = 
             requestFor HttpMethod.Get "people?role=Leader,Sublead"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [ wyatt; knope; swanson]
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People search: single campus: Pawnee`` () = 
             requestFor HttpMethod.Get "people?campus=Pawnee"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [ knope; swanson]
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People search: single campus: Indianapolis`` () = 
             requestFor HttpMethod.Get "people?campus=Indianapolis"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [ wyatt; admin ]
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People search: multiple campus: Indianapolis and Pawnee`` () = 
             requestFor HttpMethod.Get "people?campus=Pawnee,Indianapolis"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [ wyatt; admin; knope; swanson;  ]
             
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People search: single permission`` () = 
             requestFor HttpMethod.Get "people?permission=Viewer"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [knope]
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People search: multiple permission are unioned`` () = 
             requestFor HttpMethod.Get "people?permission=Viewer,Owner"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent [wyatt; knope; swanson]
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Donna is not in the directory`` () = 
             requestFor HttpMethod.Get "people?q=donna"
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent []
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Lookup of Leslie yields directory record`` () = 
             requestFor HttpMethod.Get "people-lookup?q=leslie"
             |> withAuthentication adminJwt
@@ -237,7 +237,7 @@ module ApiErrorTests =
                 let a = people |> Seq.head
                 a.NetId |> should equal knope.NetId)
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Lookup of Donna yields HR record`` () = 
             requestFor HttpMethod.Get "people-lookup?q=donna"
             |> withAuthentication adminJwt
@@ -247,7 +247,7 @@ module ApiErrorTests =
                 let a = people |> Seq.head
                 a.NetId |> should equal donnaHr.NetId)
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Add Donna to Parks unit`` () = 
             requestFor HttpMethod.Post "memberships"
             |> withAuthentication adminJwt
@@ -264,21 +264,21 @@ module ApiErrorTests =
             |> evaluateContent<UnitMember> (fun um -> 
                 um.Person.Value.NetId  |> should equal donnaHr.NetId)
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People: get by id`` () = 
             requestFor HttpMethod.Get (sprintf "people/%d" knope.Id)
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent knope
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People: get by netid`` () = 
             requestFor HttpMethod.Get (sprintf "people/%s" knope.NetId)
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.OK
             |> shouldGetContent knope
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People: get memberships by id`` () = 
             requestFor HttpMethod.Get (sprintf "people/%d/memberships" knope.Id)
             |> withAuthentication adminJwt
@@ -288,7 +288,7 @@ module ApiErrorTests =
                  let head = memberships |> Seq.head
                  head.Id |> should equal knopeMembership.Id)
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People: get memberships by netid`` () = 
             requestFor HttpMethod.Get (sprintf "people/%s/memberships" knope.NetId)
             |> withAuthentication adminJwt
@@ -298,7 +298,7 @@ module ApiErrorTests =
                  let head = memberships |> Seq.head
                  head.Id |> should equal knopeMembership.Id)
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People: admin can update any record`` () = 
             requestFor HttpMethod.Put (sprintf "people/%d" knope.Id)
             |> withAuthentication adminJwt
@@ -306,7 +306,7 @@ module ApiErrorTests =
             |> shouldGetResponse HttpStatusCode.OK
             |> evaluateContent<Person> evaluatePersonUpdate
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People: knope can update own record`` () = 
             requestFor HttpMethod.Put (sprintf "people/%d" knope.Id)
             |> withAuthentication knopeJwt
@@ -314,7 +314,7 @@ module ApiErrorTests =
             |> shouldGetResponse HttpStatusCode.OK
             |> evaluateContent<Person> evaluatePersonUpdate
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People: unit owner swanson can update member knope`` () = 
             requestFor HttpMethod.Put (sprintf "people/%d" knope.Id)
             |> withAuthentication swansonJwt
@@ -322,21 +322,21 @@ module ApiErrorTests =
             |> shouldGetResponse HttpStatusCode.OK
             |> evaluateContent<Person> evaluatePersonUpdate
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People: unit member knope can't update owner swanson`` () = 
             requestFor HttpMethod.Put (sprintf "people/%d" swanson.Id)
             |> withAuthentication knopeJwt
             |> withBody personUpdate
             |> shouldGetResponse HttpStatusCode.Forbidden
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People: unit owner swanson can't someone in another unit`` () = 
             requestFor HttpMethod.Put (sprintf "people/%d" wyatt.Id)
             |> withAuthentication swansonJwt
             |> withBody personUpdate
             |> shouldGetResponse HttpStatusCode.Forbidden
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``People: unit owner swanson can update member knope: raw`` () = 
             requestFor HttpMethod.Put (sprintf "people/%d" knope.Id)
             |> withAuthentication swansonJwt
@@ -344,7 +344,7 @@ module ApiErrorTests =
             |> shouldGetResponse HttpStatusCode.OK
             |> evaluateContent<Person> evaluatePersonUpdate
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Buildings: get all`` () = 
             requestFor HttpMethod.Get "buildings"
             |> withAuthentication swansonJwt
@@ -354,7 +354,7 @@ module ApiErrorTests =
                  let head = buildings |> Seq.head
                  head.Id |> should equal cityHall.Id)
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Buildings: get one`` () = 
             requestFor HttpMethod.Get (sprintf "buildings/%d" cityHall.Id)
             |> withAuthentication swansonJwt
@@ -362,7 +362,7 @@ module ApiErrorTests =
             |> evaluateContent<Building> (fun building ->
                  building.Id |> should equal cityHall.Id)
         
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Buildings: search name`` () = 
             requestFor HttpMethod.Get "buildings?q=pawn"
             |> withAuthentication swansonJwt
@@ -372,7 +372,7 @@ module ApiErrorTests =
                  let head = buildings |> Seq.head
                  head.Id |> should equal cityHall.Id)
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Buildings: search address`` () = 
             requestFor HttpMethod.Get "buildings?q=main"
             |> withAuthentication swansonJwt
@@ -382,7 +382,7 @@ module ApiErrorTests =
                  let head = buildings |> Seq.head
                  head.Id |> should equal cityHall.Id)
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Buildings: search code`` () = 
             requestFor HttpMethod.Get "buildings?q=pa123"
             |> withAuthentication swansonJwt
@@ -392,7 +392,7 @@ module ApiErrorTests =
                  let head = buildings |> Seq.head
                  head.Id |> should equal cityHall.Id)
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Buildings: search code with dash`` () = 
             requestFor HttpMethod.Get "buildings?q=pa-123"
             |> withAuthentication swansonJwt
@@ -402,7 +402,7 @@ module ApiErrorTests =
                  let head = buildings |> Seq.head
                  head.Id |> should equal cityHall.Id)
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Building relationships: get all`` () = 
             requestFor HttpMethod.Get "buildingRelationships"
             |> withAuthentication swansonJwt
@@ -412,7 +412,7 @@ module ApiErrorTests =
                  let head = relationships |> Seq.head
                  head.Id |> should equal buildingRelationship.Id)
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Building relationships: get one`` () = 
             requestFor HttpMethod.Get (sprintf "buildingRelationships/%d" buildingRelationship.Id)
             |> withAuthentication swansonJwt
@@ -420,7 +420,7 @@ module ApiErrorTests =
             |> evaluateContent<BuildingRelationship> (fun building ->
                  building.Id |> should equal buildingRelationship.Id)
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Building: get supporting units`` () = 
             requestFor HttpMethod.Get (sprintf "buildings/%d/supportingUnits" cityHall.Id)
             |> withAuthentication swansonJwt
@@ -462,32 +462,32 @@ module ApiErrorTests =
     type ApiErrorTests(output: ITestOutputHelper)=
         inherit HttpTestBase(output)
 
-        //[<Fact>]
+        [<Fact>]
         member __.``Unauthorized request yields 401 Unauthorized`` () = 
             requestFor HttpMethod.Get "units" 
             |> shouldGetResponse HttpStatusCode.Unauthorized
 
-        //[<Theory>]
-        //[<InlineDataAttribute("units")>]
-        //[<InlineDataAttribute("departments")>]
-        //[<InlineDataAttribute("buildings")>]
-        //[<InlineDataAttribute("memberships")>]
-        //[<InlineDataAttribute("membertools")>]
-        //[<InlineDataAttribute("supportRelationships")>]
-        //[<InlineDataAttribute("buildingRelationships")>]
-        //[<InlineDataAttribute("people")>]
+        [<Theory>]
+        [<InlineDataAttribute("units")>]
+        [<InlineDataAttribute("departments")>]
+        [<InlineDataAttribute("buildings")>]
+        [<InlineDataAttribute("memberships")>]
+        [<InlineDataAttribute("membertools")>]
+        [<InlineDataAttribute("supportRelationships")>]
+        [<InlineDataAttribute("buildingRelationships")>]
+        [<InlineDataAttribute("people")>]
         member __.``Get non-existent resource yields 404 Not Found`` (resource: string) = 
             sprintf "units/%s/1000" resource
             |> requestFor HttpMethod.Get
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        //[<Theory>]
-        //[<InlineDataAttribute("units")>]
-        //[<InlineDataAttribute("memberships")>]
-        //[<InlineDataAttribute("membertools")>]
-        //[<InlineDataAttribute("supportRelationships")>]
-        //[<InlineDataAttribute("buildingRelationships")>]
+        [<Theory>]
+        [<InlineDataAttribute("units")>]
+        [<InlineDataAttribute("memberships")>]
+        [<InlineDataAttribute("membertools")>]
+        [<InlineDataAttribute("supportRelationships")>]
+        [<InlineDataAttribute("buildingRelationships")>]
         member __.``Delete non-existent resource yields 404 Not Found`` (resource: string) = 
             sprintf "units/%s/1000" resource
             |> requestFor HttpMethod.Delete
@@ -495,7 +495,7 @@ module ApiErrorTests =
             |> shouldGetResponse HttpStatusCode.NotFound
 
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Get non-existent person`` () = 
             requestFor HttpMethod.Get "people/foo"
             |> withAuthentication adminJwt
@@ -505,21 +505,21 @@ module ApiErrorTests =
         // Units
         // *********************
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Create a unit with missing required field in request body yields 400 Bad Request`` () = 
             requestFor HttpMethod.Post "units"
             |> withAuthentication adminJwt
             |> withRawBody """{"description":"d", "url":"u", "parentId":undefined}"""
             |> shouldGetResponse HttpStatusCode.BadRequest
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Create a unit with non existent parent yields 404 Not Found`` () = 
             requestFor HttpMethod.Post "units"
             |> withAuthentication adminJwt
             |> withBody { parksAndRec with Name="test"; ParentId = Some(1000) }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Update a unit with circular relationship yields 409 Conflict`` () = 
             sprintf "units/%d" cityOfPawnee.Id
             |> requestFor HttpMethod.Put
@@ -527,7 +527,7 @@ module ApiErrorTests =
             |> withBody { cityOfPawnee with ParentId=Some(parksAndRec.Id) }
             |> shouldGetResponse HttpStatusCode.Conflict
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Delete a unit with children yields 409 Conflict`` () = 
             sprintf "units/%d" cityOfPawnee.Id
             |> requestFor HttpMethod.Delete
@@ -538,28 +538,28 @@ module ApiErrorTests =
         // Unit Memberships
         // *********************
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Create a membership with non existent unit yields 404 Not Found`` () = 
             requestFor HttpMethod.Post "memberships"
             |> withAuthentication adminJwt
             |> withBody { knopeMembership with UnitId=1000 }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Create a membership with non existent person yields 404 Not Found`` () = 
             requestFor HttpMethod.Post "memberships"
             |> withAuthentication adminJwt
             |> withBody { knopeMembership with PersonId=Some(1000) }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Create a membership that duplicates existing memberships yields 409 Conflict`` () = 
             requestFor HttpMethod.Post "memberships"
             |> withAuthentication adminJwt
             |> withBody knopeMembership
             |> shouldGetResponse HttpStatusCode.Conflict
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Update a membership that duplicates existing memberships yields 409 Conflict`` () = 
             sprintf "memberships/%d" swansonMembership.Id
             |> requestFor HttpMethod.Put
@@ -571,21 +571,21 @@ module ApiErrorTests =
         // Support Relationships
         // *********************
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Create a support relationship with non existent unit yields 404 Not Found`` () = 
             requestFor HttpMethod.Post "supportRelationships"
             |> withAuthentication adminJwt
             |> withBody { supportRelationship with UnitId=1000 }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Create a support relationship with non existent department yields 404 Not Found`` () = 
             requestFor HttpMethod.Post "supportRelationships"
             |> withAuthentication adminJwt
             |> withBody { supportRelationship with DepartmentId=1000 }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Create a supportRelationship that duplicates existing relationship yields 409 Conflict`` () = 
             requestFor HttpMethod.Post "supportRelationships"
             |> withAuthentication adminJwt
@@ -596,21 +596,21 @@ module ApiErrorTests =
         // Building Relationships
         // *********************
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Create a building relationship with non existent unit yields 404 Not Found`` () = 
             requestFor HttpMethod.Post "buildingRelationships"
             |> withAuthentication adminJwt
             |> withBody { buildingRelationship with UnitId=1000 }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Create a building relationship with non existent department yields 404 Not Found`` () = 
             requestFor HttpMethod.Post "buildingRelationships"
             |> withAuthentication adminJwt
             |> withBody { buildingRelationship with BuildingId=1000 }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Create a building relationship that duplicates existing relationship yields 409 Conflict`` () = 
             requestFor HttpMethod.Post "buildingRelationships"
             |> withAuthentication adminJwt
@@ -621,35 +621,35 @@ module ApiErrorTests =
         // Member Tools
         // *****************
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Create a member tool with non existent membership yields 404 Not Found`` () = 
             requestFor HttpMethod.Post "membertools"
             |> withAuthentication adminJwt
             |> withBody { memberTool with MembershipId=1000 }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Create a member tool with non existent tool yields 404 Not Found`` () = 
             requestFor HttpMethod.Post "membertools"
             |> withAuthentication adminJwt
             |> withBody { memberTool with ToolId=1000 }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Update a nonexistent member tool yields 404 Not Found`` () = 
             requestFor HttpMethod.Put "membertools/1000"
             |> withAuthentication adminJwt
             |> withBody memberTool
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Update a member tool with non existent membership yields 404 Not Found`` () = 
             requestFor HttpMethod.Put "membertools/1"
             |> withAuthentication adminJwt
             |> withBody { memberTool with MembershipId=1000 }
             |> shouldGetResponse HttpStatusCode.NotFound
 
-        //[<Fact>]       
+        [<Fact>]       
         member __.``Update a member tool with non existent tool yields 404 Not Found`` () = 
             requestFor HttpMethod.Put "membertools/1"
             |> withAuthentication adminJwt

--- a/functions.tests.integration/ApiErrorTests.fs
+++ b/functions.tests.integration/ApiErrorTests.fs
@@ -439,7 +439,6 @@ module ApiErrorTests =
                  arr.LspInfos |> Seq.length |> should equal 1
                  let head = arr.LspInfos |> Seq.head
                  head |> should equal lspInfo)
-
         
         [<Fact>]       
         member __.``Legacy: LspDepartments`` () = 
@@ -449,6 +448,16 @@ module ApiErrorTests =
             |> evaluateXmlContent<LspDepartmentArray> (fun arr ->
                  arr.NetworkID |> should equal wyatt.NetId 
                  arr.DeptCodeList.Values |> should equal [| parksDept.Name |] )
+
+        [<Fact>]       
+        member __.``Legacy: DepartmentLsps`` () = 
+            requestFor HttpMethod.Get (sprintf "LspdbWebService.svc/LspsInDept/%s" parksDept.Name)
+            |> withAuthentication swansonJwt
+            |> shouldGetResponse HttpStatusCode.OK
+            |> evaluateXmlContent<LspContactArray> (fun arr ->
+                 arr.LspContacts |> Seq.length |> should equal 1
+                 let head = arr.LspContacts |> Seq.head
+                 head |> should equal lspContact )
 
     type ApiErrorTests(output: ITestOutputHelper)=
         inherit HttpTestBase(output)

--- a/functions.tests.unit/ApiTests.fs
+++ b/functions.tests.unit/ApiTests.fs
@@ -3,6 +3,8 @@
 
 namespace Tests
 
+open Core.Types
+open Core.Fakes
 open Functions.Api
 open Xunit
 
@@ -13,3 +15,25 @@ module ApiTests =
     let ``can generate OpenAPI spec`` ()=
         let result = generateOpenAPISpec ()
         ()         
+
+
+    [<Fact>]
+    let ``can serialize XML`` ()=
+        let expected = """<?xml version="1.0" encoding="utf-16"?>
+<ArrayOfLspInfo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <LspInfo>
+    <IsLA>false</IsLA>
+    <NetworkID>lknope</NetworkID>
+  </LspInfo>
+</ArrayOfLspInfo>"""
+        let actual = 
+            { LspInfos = [| lspInfo|]} 
+            |> serializeXml<LspInfoArray>
+        Assert.Equal(expected, actual)
+
+    [<Fact>]
+    let ``can make XML content`` ()=
+        let actual = 
+            { LspInfos = [| lspInfo|]} 
+            |> xmlResponse<LspInfoArray>
+        printfn "XML content: %s" (actual.ToString())

--- a/functions.tests.unit/ApiTests.fs
+++ b/functions.tests.unit/ApiTests.fs
@@ -37,3 +37,11 @@ module ApiTests =
             { LspInfos = [| lspInfo|]} 
             |> xmlResponse<LspInfoArray>
         printfn "XML content: %s" (actual.ToString())
+
+    [<Fact>]
+    let ``can serialize LspDepartmentArray`` ()=
+        let record = 
+          { DeptCodeList = { Values = [|"BL-DEP1"; "BL-DEP2" |] }
+            NetworkID = "netid" } 
+        let actual = record |> serializeXml<LspDepartmentArray>
+        printfn "XML content: %s" (actual.ToString())

--- a/functions.tests.unit/ApiTests.fs
+++ b/functions.tests.unit/ApiTests.fs
@@ -19,11 +19,11 @@ module ApiTests =
 
     [<Fact>]
     let ``can serialize XML`` ()=
-        let expected = """<?xml version="1.0" encoding="utf-16"?>
+        let expected = """<?xml version="1.0" encoding="utf-8"?>
 <ArrayOfLspInfo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <LspInfo>
-    <IsLA>false</IsLA>
-    <NetworkID>lknope</NetworkID>
+    <IsLA>true</IsLA>
+    <NetworkID>bwyatt</NetworkID>
   </LspInfo>
 </ArrayOfLspInfo>"""
         let actual = 

--- a/functions/DatabaseRepository.fs
+++ b/functions/DatabaseRepository.fs
@@ -644,13 +644,17 @@ module DatabaseRepository =
 
     // LSPs are any member of a unit that has a support relationship with
     // one or more departmens. "LA" = "local administrator" = unit leader.
+    // Exclude "related" people from result.
     let queryLspListSql = """
         SELECT 
         	p.netid as NetworkID, 
-        	MAX(um.Role) = 4 as IsLA
+        	MAX(um.Role) = 4 as IsLA    -- unit 'leader' 
         FROM people p
-        JOIN unit_members um on um.person_id = p.id
-        WHERE um.unit_id in (SELECT sr.unit_id from support_relationships sr)
+        JOIN unit_members um 
+            ON um.person_id = p.id
+            AND um.role <> 1            -- exclude 'related'
+        WHERE um.unit_id IN
+         (SELECT sr.unit_id from support_relationships sr)
         GROUP BY p.netid
         ORDER BY p.netid"""
 

--- a/functions/FakesRepository.fs
+++ b/functions/FakesRepository.fs
@@ -97,6 +97,7 @@ module FakesRepository =
 
     let FakeLegacy = {
         GetLspList = fun () -> stub { LspInfos = [|lspInfo|] }
+        GetLspDepartments = fun dept -> stub lspDepartments
     }
 
     let Repository = {

--- a/functions/FakesRepository.fs
+++ b/functions/FakesRepository.fs
@@ -95,6 +95,10 @@ module FakesRepository =
         Delete = fun id -> stub ()
     }
 
+    let FakeLegacy = {
+        GetLspList = fun () -> stub { LspInfos = [|lspInfo|] }
+    }
+
     let Repository = {
         People = FakePeople
         Units = FakeUnits
@@ -106,5 +110,6 @@ module FakesRepository =
         SupportRelationships = FakeSupportRelationships
         BuildingRelationships = FakeBuildingRelationships
         Authorization = FakeAuthorization
+        Legacy = FakeLegacy
     }
 

--- a/functions/FakesRepository.fs
+++ b/functions/FakesRepository.fs
@@ -98,6 +98,7 @@ module FakesRepository =
     let FakeLegacy = {
         GetLspList = fun () -> stub { LspInfos = [|lspInfo|] }
         GetLspDepartments = fun dept -> stub lspDepartments
+        GetDepartmentLsps = fun dept -> stub { LspContacts = [|lspContact|] }
     }
 
     let Repository = {

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -110,23 +110,28 @@ module Functions =
         permission req (canModifyUnit (unitId relation)) relation     
 
     /// Execute a workflow for an authenticated user and return a response.
-    let execute (successStatus:Status) (req:HttpRequestMessage) workflow  = 
+    let inline execute (successStatus:Status) (req:HttpRequestMessage) (formatter: 'a -> StringContent) (workflow: HttpRequestMessage -> Async<Result<'a,Error>>)  = 
         async {
             try
                 let workflow = timestamp >=> workflow
-                let! result = workflow(req)
-                return! createResponse req config log successStatus result
+                match! workflow(req) with
+                | Ok body ->
+                    do! logSuccess log req successStatus
+                    return body |> formatter |> contentResponse req config.CorsHosts successStatus
+                | Error (status,msg) -> 
+                    do! logError log req status msg
+                    return msg |> jsonResponse |> contentResponse req config.CorsHosts status
             with exn -> 
                 do! logFatal log req exn
                 raise exn
                 return req.CreateErrorResponse(Status.InternalServerError, exn.Message)
         } |> Async.StartAsTask
 
-    let get req workflow = execute Status.OK req workflow
-    let create req workflow = execute Status.Created req workflow
-    let update req workflow = execute Status.OK req workflow
-    let delete req workflow = execute Status.NoContent req workflow
-
+    let get req workflow = execute Status.OK req jsonResponse workflow
+    let create req workflow = execute Status.Created req jsonResponse workflow
+    let update req workflow = execute Status.OK req jsonResponse workflow
+    let delete req workflow = execute Status.NoContent req jsonResponse workflow
+    let getXml req workflow = execute Status.OK req xmlResponse workflow
 
     let inline ensureEntityExistsForModel (getter:Id->Async<Result<'a,Error>>) model : Async<Result<'b,Error>> = async {
         let! result = getter (identity model)
@@ -150,7 +155,7 @@ module Functions =
     let openapi
         ([<HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "openapi.json")>] req) =
         let (content, status) = 
-            try (new StringContent(openApiSpec.Value), Status.OK)
+            try (openApiSpec.Value |> jsonResponse, Status.OK)
             with exn -> (new StringContent(exn.ToString()), Status.InternalServerError)
         contentResponse req "*" status content
 
@@ -158,8 +163,7 @@ module Functions =
     [<SwaggerIgnore>]
     let ping
         ([<HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "ping")>] req) =
-        new StringContent("Pong!") 
-        |> contentResponse req "*" Status.OK
+        contentResponse req "*" Status.OK (new StringContent("Pong!"))
 
     // *****************
     // ** Authentication

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -934,3 +934,15 @@ module Functions =
             >=> authorizeRelationUnitModification req
             >=> data.BuildingRelationships.Delete
         delete req workflow
+
+    // *********************************
+    // ** Legacy Endpoints
+    // *********************************
+    
+    [<FunctionName("LegacyLspList")>]
+    [<SwaggerOperation(Summary="List all IT Pros.", Tags=[|"Legacy"|])>]
+    [<SwaggerResponse(200, "A collection of people records", typeof<SupportRelationship seq>)>]
+    let legacyLspList
+        ([<HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "LspdbWebService.svc/LspList")>] req) =
+        let workflow = fun _ -> data.Legacy.GetLspList ()
+        getXml req workflow

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -953,9 +953,18 @@ module Functions =
         let workflow = fun _ -> data.Legacy.GetLspDepartments netid
         getXml req workflow    
 
+    [<FunctionName("LegacyLspPrefixes")>]
+    [<SwaggerIgnore>]
+    let legacyLspPrefixes
+        ([<HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "LspdbWebService.svc/LspPrefixes/{netid}")>] req, netid) =
+        let dummyResponse = sprintf """<LspPrefixList><NetworkID>%s</NetworkID><PrefixCodeList><a:string/></PrefixCodeList></LspPrefixList>""" netid
+        new StringContent(dummyResponse, Text.Encoding.UTF8, formatXml)
+        |> contentResponse req "*" Status.OK
+
     [<FunctionName("LegacyDepartmentLsps")>]
     [<SwaggerIgnore>]
     let legacyDepartmentLsps
         ([<HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "LspdbWebService.svc/LspsInDept/{department}")>] req, department) =
         let workflow = fun _ -> data.Legacy.GetDepartmentLsps department
         getXml req workflow   
+

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -952,3 +952,10 @@ module Functions =
         ([<HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "LspdbWebService.svc/LspDepartments/{netid}")>] req, netid) =
         let workflow = fun _ -> data.Legacy.GetLspDepartments netid
         getXml req workflow    
+
+    [<FunctionName("LegacyDepartmentLsps")>]
+    [<SwaggerIgnore>]
+    let legacyDepartmentLsps
+        ([<HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "LspdbWebService.svc/LspsInDept/{department}")>] req, department) =
+        let workflow = fun _ -> data.Legacy.GetDepartmentLsps department
+        getXml req workflow   

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -940,9 +940,15 @@ module Functions =
     // *********************************
     
     [<FunctionName("LegacyLspList")>]
-    [<SwaggerOperation(Summary="List all IT Pros.", Tags=[|"Legacy"|])>]
-    [<SwaggerResponse(200, "A collection of people records", typeof<SupportRelationship seq>)>]
+    [<SwaggerIgnore>]
     let legacyLspList
         ([<HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "LspdbWebService.svc/LspList")>] req) =
         let workflow = fun _ -> data.Legacy.GetLspList ()
         getXml req workflow
+
+    [<FunctionName("LegacyLspDepartments")>]
+    [<SwaggerIgnore>]
+    let legacyLspDepartments
+        ([<HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "LspdbWebService.svc/LspDepartments/{netid}")>] req, netid) =
+        let workflow = fun _ -> data.Legacy.GetLspDepartments netid
+        getXml req workflow    


### PR DESCRIPTION
An examination of webserver logs of the existing IT Pro Database indicated that four endpoints are still in use by various scripts/systems around UITS. Those endpoints will need to continue to working without interruption when we cut the legacy domains over to the new IT People application.  This PR implements those endpoints. 