### PR TITLE
Remove reponse body from Delete requests

### DIFF
--- a/database/Command.fs
+++ b/database/Command.fs
@@ -153,17 +153,21 @@ module Command =
 
     let inline delete< ^T when ^T: (member Id:Id)> connStr (obj:^T) = async {
         try
+            printfn "***** START DELETE *****"
             let id = (identity obj)
             use cn = new NpgsqlConnection(connStr)
             let! _ = cn.DeleteAsync<'T>(id) |> Async.AwaitTask
+            printfn "***** FINISHED DELETE *****"
             return () |> Ok
-        with exn -> return handleDbExn "update" (typedefof<'T>.Name) exn
+        with exn -> return handleDbExn "delete" (typedefof<'T>.Name) exn
     }
 
     let execute connStr sql parameters = async {
         try
+            printfn "***** START EXECUTE *****"
             use cn = new NpgsqlConnection(connStr)
             let! _ = cn.ExecuteAsync(sql, parameters) |> Async.AwaitTask
+            printfn "***** FINISHED EXECUTE *****"
             return () |> Ok
         with exn -> return handleDbExn "execute" "" exn
     }

--- a/database/Command.fs
+++ b/database/Command.fs
@@ -153,21 +153,17 @@ module Command =
 
     let inline delete< ^T when ^T: (member Id:Id)> connStr (obj:^T) = async {
         try
-            printfn "***** START DELETE *****"
             let id = (identity obj)
             use cn = new NpgsqlConnection(connStr)
             let! _ = cn.DeleteAsync<'T>(id) |> Async.AwaitTask
-            printfn "***** FINISHED DELETE *****"
             return () |> Ok
         with exn -> return handleDbExn "delete" (typedefof<'T>.Name) exn
     }
 
     let execute connStr sql parameters = async {
         try
-            printfn "***** START EXECUTE *****"
             use cn = new NpgsqlConnection(connStr)
             let! _ = cn.ExecuteAsync(sql, parameters) |> Async.AwaitTask
-            printfn "***** FINISHED EXECUTE *****"
             return () |> Ok
         with exn -> return handleDbExn "execute" "" exn
     }

--- a/functions.tests.integration/ApiErrorTests.fs
+++ b/functions.tests.integration/ApiErrorTests.fs
@@ -460,14 +460,12 @@ module ApiErrorTests =
             requestFor HttpMethod.Delete (sprintf "buildingRelationships/%d" buildingRelationship.Id)
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.NoContent
-            |> evaluateRawContent (fun content -> content |> should equal "")
 
         [<Fact>]       
         member __.``Support relationships: delete`` () = 
             requestFor HttpMethod.Delete (sprintf "supportRelationships/%d" supportRelationship.Id)
             |> withAuthentication adminJwt
             |> shouldGetResponse HttpStatusCode.NoContent
-            |> evaluateRawContent (fun content -> content |> should equal "")
         
         [<Fact>]       
         member __.``Legacy: LspList`` () = 

--- a/functions.tests.integration/ApiErrorTests.fs
+++ b/functions.tests.integration/ApiErrorTests.fs
@@ -65,6 +65,10 @@ module ApiErrorTests =
         response |> parseContent<'T> |> evalFn
         response    
 
+    let evaluateRawContent(evalFn:string -> unit) (response:HttpResponseMessage) =
+        response |> readContent |> evalFn
+        response    
+
     let evaluateXmlContent<'T> (evalFn:'T -> unit) (response:HttpResponseMessage) =
         response |> parseXmlContent<'T> |> evalFn
         response    
@@ -450,6 +454,20 @@ module ApiErrorTests =
                  relationships |> Seq.length |> should equal 1
                  let head = relationships |> Seq.head
                  head.Id |> should equal buildingRelationship.Id)
+
+        [<Fact>]       
+        member __.``Building relationships: delete`` () = 
+            requestFor HttpMethod.Delete (sprintf "buildingRelationships/%d" buildingRelationship.Id)
+            |> withAuthentication adminJwt
+            |> shouldGetResponse HttpStatusCode.NoContent
+            |> evaluateRawContent (fun content -> content |> should equal "")
+
+        [<Fact>]       
+        member __.``Support relationships: delete`` () = 
+            requestFor HttpMethod.Delete (sprintf "supportRelationships/%d" supportRelationship.Id)
+            |> withAuthentication adminJwt
+            |> shouldGetResponse HttpStatusCode.NoContent
+            |> evaluateRawContent (fun content -> content |> should equal "")
         
         [<Fact>]       
         member __.``Legacy: LspList`` () = 

--- a/functions/Api.fs
+++ b/functions/Api.fs
@@ -159,11 +159,15 @@ let xmlContent = stringContent "application/xml"
 let textContent = stringContent "text/plain"
 let htmlContent = stringContent "text/html"
 
-let contentResponse req corsHosts status content  = 
+let emptyResponse req corsHosts status  = 
     let response = new HttpResponseMessage(status)
-    response.Content <- content
     addCORSHeader response (origin req) corsHosts
     addPermissionsHeader req response
+    response
+
+let contentResponse req corsHosts status content  = 
+    let response = emptyResponse req corsHosts status
+    response.Content <- content
     response
 
 let serializeJson model = 
@@ -173,8 +177,7 @@ let serializeJson model =
 let inline jsonResponse model = 
     model |> serializeJson |> jsonContent
 
-let emptyResponse () = 
-    System.Object () |> jsonResponse
+let noContent () = new StringContent("")
 
 type Utf8StringWriter()=
     inherit System.IO.StringWriter()

--- a/functions/Api.fs
+++ b/functions/Api.fs
@@ -173,6 +173,9 @@ let serializeJson model =
 let inline jsonResponse model = 
     model |> serializeJson |> jsonContent
 
+let emptyResponse () = 
+    "{}" |> jsonContent
+
 type Utf8StringWriter()=
     inherit System.IO.StringWriter()
     override __.Encoding = System.Text.Encoding.UTF8

--- a/functions/Api.fs
+++ b/functions/Api.fs
@@ -174,7 +174,7 @@ let inline jsonResponse model =
     model |> serializeJson |> jsonContent
 
 let emptyResponse () = 
-    "{}" |> jsonContent
+    System.Object () |> jsonResponse
 
 type Utf8StringWriter()=
     inherit System.IO.StringWriter()

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -118,13 +118,11 @@ module Functions =
                 let workflow = timestamp >=> workflow
                 match! workflow(req) with
                 | Ok body ->
-                    printfn "***** WORKFLOW SUCCEDED WITH BODY: %O *****" body
                     do! logSuccess log req successStatus
                     match formatter with
                     | None -> return emptyResponse req config.CorsHosts successStatus 
                     | Some(fmt) -> return body |> fmt |> contentResponse req config.CorsHosts successStatus
                 | Error (status,msg) -> 
-                    printfn "***** WORKFLOW ERRORED WITH: %s *****" msg
                     do! logError log req status msg
                     return msg |> jsonResponse |> contentResponse req config.CorsHosts status
             with exn -> 

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -130,7 +130,7 @@ module Functions =
     let get req workflow = execute Status.OK req jsonResponse workflow
     let create req workflow = execute Status.Created req jsonResponse workflow
     let update req workflow = execute Status.OK req jsonResponse workflow
-    let delete req workflow = execute Status.NoContent req jsonResponse workflow
+    let delete req workflow = execute Status.NoContent req emptyResponse workflow
     let getXml req workflow = execute Status.OK req xmlResponse workflow
 
     let inline ensureEntityExistsForModel (getter:Id->Async<Result<'a,Error>>) model : Async<Result<'b,Error>> = async {

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -109,8 +109,10 @@ module Functions =
     let inline permissionRelationUnitModification req relation =
         permission req (canModifyUnit (unitId relation)) relation     
 
+    type Formatter<'a> = 'a -> StringContent
+
     /// Execute a workflow for an authenticated user and return a response.
-    let inline execute (successStatus:Status) (req:HttpRequestMessage) (formatter: 'a -> StringContent) (workflow: HttpRequestMessage -> Async<Result<'a,Error>>)  = 
+    let inline execute (successStatus:Status) (req:HttpRequestMessage) (formatter: Formatter<'a> option) (workflow: HttpRequestMessage -> Async<Result<'a,Error>>)  = 
         async {
             try
                 let workflow = timestamp >=> workflow
@@ -118,9 +120,9 @@ module Functions =
                 | Ok body ->
                     printfn "***** WORKFLOW SUCCEDED WITH BODY: %O *****" body
                     do! logSuccess log req successStatus
-                    match successStatus with
-                    | Status.NoContent -> return emptyResponse req config.CorsHosts successStatus 
-                    | _ -> return body |> formatter |> contentResponse req config.CorsHosts successStatus
+                    match formatter with
+                    | None -> return emptyResponse req config.CorsHosts successStatus 
+                    | Some(fmt) -> return body |> fmt |> contentResponse req config.CorsHosts successStatus
                 | Error (status,msg) -> 
                     printfn "***** WORKFLOW ERRORED WITH: %s *****" msg
                     do! logError log req status msg
@@ -131,11 +133,11 @@ module Functions =
                 return req.CreateErrorResponse(Status.InternalServerError, exn.Message)
         } |> Async.StartAsTask
 
-    let get req workflow = execute Status.OK req jsonResponse workflow
-    let create req workflow = execute Status.Created req jsonResponse workflow
-    let update req workflow = execute Status.OK req jsonResponse workflow
-    let delete req workflow = execute Status.NoContent req noContent workflow
-    let getXml req workflow = execute Status.OK req xmlResponse workflow
+    let get req workflow = execute Status.OK req (Some jsonResponse) workflow
+    let create req workflow = execute Status.Created req (Some jsonResponse) workflow
+    let update req workflow = execute Status.OK req (Some jsonResponse) workflow
+    let delete req workflow = execute Status.NoContent req None workflow
+    let getXml req workflow = execute Status.OK req (Some xmlResponse) workflow
 
     let inline ensureEntityExistsForModel (getter:Id->Async<Result<'a,Error>>) model : Async<Result<'b,Error>> = async {
         let! result = getter (identity model)

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -116,9 +116,11 @@ module Functions =
                 let workflow = timestamp >=> workflow
                 match! workflow(req) with
                 | Ok body ->
+                    printfn "***** WORKFLOW SUCCEDED WITH BODY: %O *****" body
                     do! logSuccess log req successStatus
                     return body |> formatter |> contentResponse req config.CorsHosts successStatus
                 | Error (status,msg) -> 
+                    printfn "***** WORKFLOW ERRORED WITH: %s *****" msg
                     do! logError log req status msg
                     return msg |> jsonResponse |> contentResponse req config.CorsHosts status
             with exn -> 
@@ -931,6 +933,31 @@ module Functions =
             >=> authorizeRelationUnitModification req
             >=> data.BuildingRelationships.Delete
         delete req workflow
+
+    [<FunctionName("BuildingRelationshipsDelete1")>]
+    let buildingRelationshipsDelete1
+        ([<HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "buildingRelationships1")>] req:HttpRequestMessage) =
+        req.CreateResponse(Status.NoContent)
+
+    [<FunctionName("BuildingRelationshipsDelete1Async")>]
+    let buildingRelationshipsDelete1Async
+        ([<HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "buildingRelationships1Async")>] req:HttpRequestMessage) = 
+        async {
+            return req.CreateResponse(Status.NoContent)
+        } |> Async.StartAsTask
+
+    [<FunctionName("BuildingRelationshipsDelete2")>]
+    let buildingRelationshipsDelete2
+        ([<HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "buildingRelationships2")>] req:HttpRequestMessage) =
+        req.CreateResponse(Status.NoContent, Object())
+
+    [<FunctionName("BuildingRelationshipsDelete2Async")>]
+    let buildingRelationshipsDelete2Async
+        ([<HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "buildingRelationships2Async")>] req:HttpRequestMessage) = 
+        async {
+            return req.CreateResponse(Status.NoContent, Object())
+        } |> Async.StartAsTask
+
 
     // *********************************
     // ** Legacy Endpoints

--- a/functions/Functions.fs
+++ b/functions/Functions.fs
@@ -118,7 +118,9 @@ module Functions =
                 | Ok body ->
                     printfn "***** WORKFLOW SUCCEDED WITH BODY: %O *****" body
                     do! logSuccess log req successStatus
-                    return body |> formatter |> contentResponse req config.CorsHosts successStatus
+                    match successStatus with
+                    | Status.NoContent -> return emptyResponse req config.CorsHosts successStatus 
+                    | _ -> return body |> formatter |> contentResponse req config.CorsHosts successStatus
                 | Error (status,msg) -> 
                     printfn "***** WORKFLOW ERRORED WITH: %s *****" msg
                     do! logError log req status msg
@@ -132,7 +134,7 @@ module Functions =
     let get req workflow = execute Status.OK req jsonResponse workflow
     let create req workflow = execute Status.Created req jsonResponse workflow
     let update req workflow = execute Status.OK req jsonResponse workflow
-    let delete req workflow = execute Status.NoContent req emptyResponse workflow
+    let delete req workflow = execute Status.NoContent req noContent workflow
     let getXml req workflow = execute Status.OK req xmlResponse workflow
 
     let inline ensureEntityExistsForModel (getter:Id->Async<Result<'a,Error>>) model : Async<Result<'b,Error>> = async {
@@ -933,31 +935,6 @@ module Functions =
             >=> authorizeRelationUnitModification req
             >=> data.BuildingRelationships.Delete
         delete req workflow
-
-    [<FunctionName("BuildingRelationshipsDelete1")>]
-    let buildingRelationshipsDelete1
-        ([<HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "buildingRelationships1")>] req:HttpRequestMessage) =
-        req.CreateResponse(Status.NoContent)
-
-    [<FunctionName("BuildingRelationshipsDelete1Async")>]
-    let buildingRelationshipsDelete1Async
-        ([<HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "buildingRelationships1Async")>] req:HttpRequestMessage) = 
-        async {
-            return req.CreateResponse(Status.NoContent)
-        } |> Async.StartAsTask
-
-    [<FunctionName("BuildingRelationshipsDelete2")>]
-    let buildingRelationshipsDelete2
-        ([<HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "buildingRelationships2")>] req:HttpRequestMessage) =
-        req.CreateResponse(Status.NoContent, Object())
-
-    [<FunctionName("BuildingRelationshipsDelete2Async")>]
-    let buildingRelationshipsDelete2Async
-        ([<HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "buildingRelationships2Async")>] req:HttpRequestMessage) = 
-        async {
-            return req.CreateResponse(Status.NoContent, Object())
-        } |> Async.StartAsTask
-
 
     // *********************************
     // ** Legacy Endpoints


### PR DESCRIPTION
Delete endpoints return a 204 (No Content) status code. However, they were also returning an empty response body. Due to some serialization peculiarities these responses had a non-zero content length, which led clients to believe that data was forthcoming when it actually wasn't.

This PR changes the response formulation such that the response body is truly optional.