### PR TITLE
Sync HR departments from HR data feed

### DIFF
--- a/core/Fakes.fs
+++ b/core/Fakes.fs
@@ -106,6 +106,7 @@ let donnaHr:HrPerson = {
     CampusPhone=""
     CampusEmail="dmeagle@pawnee.in.us"
     HrDepartment="PA-PARKS"
+    HrDepartmentDescription="PAWNEE PARKS AND REC"
 }
 
 let tool: Tool = 

--- a/core/Types.fs
+++ b/core/Types.fs
@@ -156,8 +156,10 @@ type HrPerson =
     [<Column("campus_phone")>] CampusPhone: string
     /// The campus (work) email address of this person.
     [<Column("campus_email")>] CampusEmail: string 
-    /// Administrative notes about this person, visible only to IT Admins.
-    [<Column("hr_department")>] HrDepartment: string }
+    /// The short name of the person's HR department (e.g. UA-VPIT).
+    [<Column("hr_department")>] HrDepartment: string
+    /// The long name / description of the person's HR department.
+    [<Column("hr_department_desc")>] HrDepartmentDescription: string }
 
 /// A person doing or supporting IT work
 [<CLIMutable>]

--- a/database/Migrations/15_AddDeptDescFieldToHrPeople.fs
+++ b/database/Migrations/15_AddDeptDescFieldToHrPeople.fs
@@ -1,0 +1,18 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
+namespace Migrations
+open SimpleMigrations
+
+[<Migration(15L, "Add HR department description column to HR people table")>]
+type AddDeptDescFieldToHrPeopleTable() =
+  inherit Migration()
+  override __.Up() =
+    base.Execute("""
+    ALTER TABLE hr_people ADD COLUMN hr_department_desc text NULL;
+    """)
+
+  override __.Down() =
+    base.Execute("""
+    ALTER TABLE hr_people DROP COLUMN hr_department_desc;
+    """)

--- a/tasks/Functions.fs
+++ b/tasks/Functions.fs
@@ -7,7 +7,6 @@ module Types=
     open Core.Types
 
     type ADPath = string
-
     type ADGroupMember = NetId * ADPath
     
     type ToolPersonUpdate =
@@ -33,7 +32,8 @@ module Types=
         InsertHistoricalPersonAndRemoveMemberships: Person * seq<HistoricalPersonUnitMetadata> -> Async<Result<Person * seq<HistoricalPersonUnitMetadata>, Error>>
         InsertHistoricalPersonAndDeletePerson: Person *  seq<HistoricalPersonUnitMetadata> -> Async<Result<Person, Error>>
         FetchAllHrPeople: unit -> Async<Result<seq<HrPerson>, Error>>
-        UpdateHrPeople: seq<HrPerson> -> Async<Result<unit, Error>> }
+        UpdateHrPeople: seq<HrPerson> -> Async<Result<unit, Error>>
+        SyncDepartments: unit -> Async<Result<unit, Error>> }
 
 module DataRepository =
     open Types
@@ -54,6 +54,7 @@ module DataRepository =
     type ProfileJob = 
       { jobStatus: string 
         jobDepartmentId: string
+        jobDepartmentDesc: string
         position: string }
     type ProfileContact =
       { phoneNumber: string 
@@ -120,10 +121,10 @@ module DataRepository =
     let mapEmployeesToDomainRecords (list:seq<ProfileEmployee>) = 
         printfn "%s Fetched %d people from HR source." (DateTime.Now.ToLongTimeString()) (list |> Seq.length)
         let toDomainRecord e =
-            let (position, dept) = 
+            let (position, deptName, deptDesc) = 
                 match e.jobs |> Seq.tryFind (fun j -> j.jobStatus = "P") with
-                | Some(job) -> (job.position, job.jobDepartmentId)
-                | None -> ("","")
+                | Some(job) -> (job.position, job.jobDepartmentId, job.jobDepartmentDesc)
+                | None -> ("","","")
             let (phone, campus) = 
                 match e.contacts |> Seq.tryHead with
                 | Some(contact) -> (contact.phoneNumber, contact.campusCode)
@@ -132,7 +133,8 @@ module DataRepository =
               Name=sprintf "%s %s" e.firstName e.lastName
               NetId=e.username.ToLower()
               Position=position
-              HrDepartment=dept
+              HrDepartment=deptName
+              HrDepartmentDescription=deptDesc
               Campus=campus
               CampusEmail=e.email
               CampusPhone=phone }
@@ -218,18 +220,32 @@ module DataRepository =
         let param = {Id=tool.Id}
         fetch (fun cn -> cn.QueryAsync<NetId>(sql, param)) connStr
 
-    open NpgsqlTypes
+    let syncDepartments connStr =
+        let sql = """
+            -- 1. Add any new hr departments
+            INSERT INTO departments (name, description)
+            SELECT DISTINCT hr_department, hr_department_desc
+	        FROM hr_people
+	        WHERE hr_department IS NOT NULL
+            ON CONFLICT (name)
+            DO NOTHING;
+            -- 2. Update department descriptions 
+            UPDATE departments d
+            SET description = hr_department_desc
+            FROM hr_people hr
+            WHERE d.name = hr.hr_department"""
+        execute connStr sql ()
 
     let updateHrPeople psqlConnStr (hrPeople:seq<HrPerson>) =
         // convert the hr person to a formatting string representing the table row data.
         let toRow (p:HrPerson) = 
-            sprintf "%s\t%s\t%s\t%s\t%s\t%s\t%s\n" p.Name p.NetId p.Position p.Campus p.CampusPhone p.CampusEmail p.HrDepartment 
-        Database.Command.executeRaw psqlConnStr (fun cn ->
+            sprintf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" p.Name p.NetId p.Position p.Campus p.CampusPhone p.CampusEmail p.HrDepartment p.HrDepartmentDescription
+        executeRaw psqlConnStr (fun cn ->
             cn.Open()
             // truncate the existing
             cn.Execute("DELETE FROM hr_people;") |> ignore
             // bulk insert the new rows
-            use writer = cn.BeginTextImport("COPY hr_people (name, netid, position, campus, campus_phone, campus_email, hr_department) FROM STDIN")
+            use writer = cn.BeginTextImport("COPY hr_people (name, netid, position, campus, campus_phone, campus_email, hr_department, hr_department_desc) FROM STDIN")
             hrPeople |> Seq.map toRow  |> Seq.iter writer.Write
             // flush the writer to finish the bulk insert
             writer.Flush()
@@ -390,7 +406,8 @@ module DataRepository =
        InsertHistoricalPersonAndRemoveMemberships = insertHistoricalPersonAndRemoveMemberships psqlConnStr
        InsertHistoricalPersonAndDeletePerson = insertHistoricalPersonAndDeletePerson psqlConnStr
        FetchAllHrPeople = fetchAllHrPeople uaaUrl hrDataUrl uaaUser uaaPassword
-       UpdateHrPeople = updateHrPeople psqlConnStr }
+       UpdateHrPeople = updateHrPeople psqlConnStr
+       SyncDepartments = fun () -> syncDepartments psqlConnStr }
 
 module Functions=
 
@@ -445,38 +462,22 @@ module Functions=
     // canonical HR data.
     [<FunctionName("PeopleUpdateHrTable")>]
     let peopleUpdateHrTable
-        ([<TimerTrigger("0 0 7-22 * * *")>] timer: TimerInfo,
-         [<Queue("people-update-batch")>] queue: ICollector<string>,
+        ([<TimerTrigger("0 0 * * * *")>] timer: TimerInfo,
+         [<Queue("people-update")>] queue: ICollector<string>,
          log: ILogger) = 
 
-        let enqueueBatchUpdate () = 
-            queue.Add ("go go gadget update directory people!")
+        let enqueueAllNetIds =
+            Seq.iter queue.Add
+
+        let logEnqueuedNumber netids = 
+            sprintf "Enqueued %d netids for update." (Seq.length netids)
+            |> log.LogInformation
 
         let workflow = 
             data.FetchAllHrPeople
             >=> data.UpdateHrPeople
-            >=> tap enqueueBatchUpdate
-
-        execute workflow ()
-
-    // Enqueue the netids of all the people for whom we need to update
-    // canonical HR data.
-    [<FunctionName("PeopleUpdateBatcher")>]
-    let peopleUpdateBatcher
-        ([<QueueTrigger("people-update-batch")>] msg: string,
-         [<Queue("people-update")>] queue: ICollector<string>,
-         log: ILogger) = 
-        
-        let enqueueAllNetIds =
-            Seq.iter queue.Add
-
-        let logEnqueuedNumber = 
-            Seq.length
-            >> sprintf "Enqueued %d netids for update."
-            >> log.LogInformation
-
-        let workflow = 
-            data.GetAllNetIds
+            >=> data.SyncDepartments
+            >=> data.GetAllNetIds
             >=> tap enqueueAllNetIds
             >=> tap logEnqueuedNumber
 

--- a/tasks/Functions.fs
+++ b/tasks/Functions.fs
@@ -462,7 +462,7 @@ module Functions=
     // canonical HR data.
     [<FunctionName("PeopleUpdateHrTable")>]
     let peopleUpdateHrTable
-        ([<TimerTrigger("0 0 * * * *", RunOnStartup=true)>] timer: TimerInfo,
+        ([<TimerTrigger("0 0 * * * *")>] timer: TimerInfo,
          [<Queue("people-update")>] queue: ICollector<string>,
          log: ILogger) = 
 

--- a/tasks/Functions.fs
+++ b/tasks/Functions.fs
@@ -462,7 +462,7 @@ module Functions=
     // canonical HR data.
     [<FunctionName("PeopleUpdateHrTable")>]
     let peopleUpdateHrTable
-        ([<TimerTrigger("0 0 * * * *")>] timer: TimerInfo,
+        ([<TimerTrigger("0 0 * * * *", RunOnStartup=true)>] timer: TimerInfo,
          [<Queue("people-update")>] queue: ICollector<string>,
          log: ILogger) = 
 


### PR DESCRIPTION
We have historically had a problem in which new HR departments are not known to the directory and staffers can become 'orphaned'. The HR data feed from IMS includes both department names (e.g. "UA-VPIT") and descriptions. We can use this information to keep the directory's departments up to date and prevent the orphaning of staffers.

* Add a field for the HR department description to the `hr_people` table.
* Update the HR data update to persist the department description along with the name.
* Update the `PeopleUpdateHrTable` task to include a step that syncs the `departments` table with department names/descriptions from the `hr_people` table.

Housekeeping:
* Refactor the `PeopleUpdateBatcher` task into the `PeopleUpdateHrTable` task. These never needed to be separate.