### PR TITLE
Add an optional email field to unit records

### DIFF
--- a/core/Fakes.fs
+++ b/core/Fakes.fs
@@ -8,10 +8,10 @@ let swansonJwt = { access_token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2Vy
 let knopeJwt = { access_token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX25hbWUiOiJsa25vcGUiLCJleHAiOjI5MTYyMzkwMjJ9.OfrJ3jSh91RXhfXGbi8sfZSrSdJH51Wz_46Dae2BlupaRPX6Rwn5JrHeW2dx3a8M5uVHPY7Av6kfFOCPwbHZHWIdGkQOgGMX20Yck5Utz7j8heEOwfXPQUvi5QD8UgC9NZCgxUNbWHkTF1H2awYECeuGCz6bZyHLoh357jGt5sG5yriuaAo2qnghc5vz70ZwHjTZaHrCdlpKkjxYfSCgcWiHYUfQ3gkUTIXJfoVNbcVst0k7t2T81hz5T-t7Iocgl3_daZ8wsiUMup1aypNwrUgdtNElYYqSBn8gbQ-kx6enzMMIgaWgXlct0r2f5MfplM5tIwxOgGbi2DMvgGAcHg" }
 let fakePublicKey = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnzyis1ZjfNB0bBgKFMSv\nvkTtwlvBsaJq7S5wA+kzeVOVpVWwkWdVha4s38XM/pa/yr47av7+z3VTmvDRyAHc\naT92whREFpLv9cj5lTeJSibyr/Mrm/YtjCZVWgaOYIhwrXwKLqPr/11inWsAkfIy\ntvHWTxZYEcXLgAXFuUuaS3uF9gEiNQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0\ne+lf4s4OxQawWD79J9/5d3Ry0vbV3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWb\nV6L11BWkpzGXSW4Hv43qa+GSYOD2QU68Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9\nMwIDAQAB\n-----END PUBLIC KEY-----"
 // Units
-let cityOfPawnee:Unit = {Id=1; Name="City of Pawnee"; Description="City of Pawnee, Indiana"; Url="http://pawneeindiana.com/"; ParentId=None; Parent=None}
-let parksAndRec:Unit = {Id=2; Name="Parks and Rec"; Description="Parks and Recreation"; Url="http://pawneeindiana.com/parks-and-recreation/"; ParentId=Some(cityOfPawnee.Id); Parent=Some(cityOfPawnee)}
-let fourthFloor:Unit = {Id=3; Name="Fourth Floor"; Description="City Hall's Fourth Floor"; Url="http://pawneeindiana.com/fourth-floor/"; ParentId=Some(cityOfPawnee.Id); Parent=Some(cityOfPawnee)}
-let edgeUnit:Unit = {Id=4; Name="Edge Unit"; Description="Edge Unit"; Url=""; ParentId=None; Parent=None}
+let cityOfPawnee:Unit = {Id=1; Name="City of Pawnee"; Description="City of Pawnee, Indiana"; Url="http://pawneeindiana.com/"; Email="unit@example.com"; ParentId=None; Parent=None}
+let parksAndRec:Unit = {Id=2; Name="Parks and Rec"; Description="Parks and Recreation"; Url="http://pawneeindiana.com/parks-and-recreation/"; Email="unit@example.com"; ParentId=Some(cityOfPawnee.Id); Parent=Some(cityOfPawnee)}
+let fourthFloor:Unit = {Id=3; Name="Fourth Floor"; Description="City Hall's Fourth Floor"; Url="http://pawneeindiana.com/fourth-floor/"; Email="unit@example.com"; ParentId=Some(cityOfPawnee.Id); Parent=Some(cityOfPawnee)}
+let edgeUnit:Unit = {Id=4; Name="Edge Unit"; Description="Edge Unit"; Url=""; Email=""; ParentId=None; Parent=None}
 let parksAndRecUnitRequest:UnitRequest = { Name="Parks and Rec"; Description="Parks and Recreation"; Url="http://pawneeindiana.com/parks-and-recreation/"; ParentId=Some(cityOfPawnee.Id) }
 
 // Departments

--- a/core/Fakes.fs
+++ b/core/Fakes.fs
@@ -8,7 +8,7 @@ let swansonJwt = { access_token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2Vy
 let knopeJwt = { access_token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX25hbWUiOiJsa25vcGUiLCJleHAiOjI5MTYyMzkwMjJ9.OfrJ3jSh91RXhfXGbi8sfZSrSdJH51Wz_46Dae2BlupaRPX6Rwn5JrHeW2dx3a8M5uVHPY7Av6kfFOCPwbHZHWIdGkQOgGMX20Yck5Utz7j8heEOwfXPQUvi5QD8UgC9NZCgxUNbWHkTF1H2awYECeuGCz6bZyHLoh357jGt5sG5yriuaAo2qnghc5vz70ZwHjTZaHrCdlpKkjxYfSCgcWiHYUfQ3gkUTIXJfoVNbcVst0k7t2T81hz5T-t7Iocgl3_daZ8wsiUMup1aypNwrUgdtNElYYqSBn8gbQ-kx6enzMMIgaWgXlct0r2f5MfplM5tIwxOgGbi2DMvgGAcHg" }
 let fakePublicKey = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnzyis1ZjfNB0bBgKFMSv\nvkTtwlvBsaJq7S5wA+kzeVOVpVWwkWdVha4s38XM/pa/yr47av7+z3VTmvDRyAHc\naT92whREFpLv9cj5lTeJSibyr/Mrm/YtjCZVWgaOYIhwrXwKLqPr/11inWsAkfIy\ntvHWTxZYEcXLgAXFuUuaS3uF9gEiNQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0\ne+lf4s4OxQawWD79J9/5d3Ry0vbV3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWb\nV6L11BWkpzGXSW4Hv43qa+GSYOD2QU68Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9\nMwIDAQAB\n-----END PUBLIC KEY-----"
 // Units
-let cityOfPawnee:Unit = {Id=1; Name="City of Pawnee"; Description="City of Pawnee, Indiana"; Url="http://pawneeindiana.com/"; Email="unit@example.com"; ParentId=None; Parent=None}
+let cityOfPawnee:Unit = {Id=1; Name="City of Pawnee"; Description="City of Pawnee, Indiana"; Url="http://pawneeindiana.com/"; Email="city@pawnee.in.us"; ParentId=None; Parent=None}
 let parksAndRec:Unit = {Id=2; Name="Parks and Rec"; Description="Parks and Recreation"; Url="http://pawneeindiana.com/parks-and-recreation/"; Email="unit@example.com"; ParentId=Some(cityOfPawnee.Id); Parent=Some(cityOfPawnee)}
 let fourthFloor:Unit = {Id=3; Name="Fourth Floor"; Description="City Hall's Fourth Floor"; Url="http://pawneeindiana.com/fourth-floor/"; Email="unit@example.com"; ParentId=Some(cityOfPawnee.Id); Parent=Some(cityOfPawnee)}
 let edgeUnit:Unit = {Id=4; Name="Edge Unit"; Description="Edge Unit"; Url=""; Email=""; ParentId=None; Parent=None}
@@ -254,5 +254,5 @@ let lspContact = {
   FullName=wyatt.Name
   GroupInternalEmail=""
   Phone=wyatt.CampusPhone
-  PreferredEmail=wyatt.CampusEmail
+  PreferredEmail=cityOfPawnee.Email
 }

--- a/core/Types.fs
+++ b/core/Types.fs
@@ -221,6 +221,9 @@ type Unit =
     /// A URL for the website of this unit.
     [<DefaultValue("")>]
     [<Column("url")>] Url: string
+    /// A contact email for this unit.
+    [<DefaultValue("")>]
+    [<Column("email")>] Email: string
     /// The unique ID of the parent unit of this unit.
     [<DefaultValue(null)>]
     [<Column("parent_id")>][<Editable(true)>] ParentId: Id option 

--- a/database/Migrations/16_AddEmailFieldToUnit.fs
+++ b/database/Migrations/16_AddEmailFieldToUnit.fs
@@ -1,0 +1,18 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
+namespace Migrations
+open SimpleMigrations
+
+[<Migration(16L, "Add optional email column to units table")>]
+type AddEmailFieldToUnit() =
+  inherit Migration()
+  override __.Up() =
+    base.Execute("""
+    ALTER TABLE units ADD COLUMN email text NULL;
+    """)
+
+  override __.Down() =
+    base.Execute("""
+    ALTER TABLE units DROP COLUMN email;
+    """)

--- a/functions.tests.integration/ContractTests.fs
+++ b/functions.tests.integration/ContractTests.fs
@@ -35,7 +35,7 @@ module ContractTests =
                 .ProviderState(stateServerUrl)
                 .ServiceProvider("API", functionServerUrl)
                 .HonoursPactWith("Client")
-                .PactUri("https://raw.githubusercontent.com/indiana-university/itpeople-app/feature/unit-contact-email/contracts/itpeople-app-itpeople-functions.json")
+                .PactUri("https://raw.githubusercontent.com/indiana-university/itpeople-app/develop/contracts/itpeople-app-itpeople-functions.json")
                 .Verify()
 
         [<Fact>]

--- a/functions.tests.integration/ContractTests.fs
+++ b/functions.tests.integration/ContractTests.fs
@@ -35,7 +35,7 @@ module ContractTests =
                 .ProviderState(stateServerUrl)
                 .ServiceProvider("API", functionServerUrl)
                 .HonoursPactWith("Client")
-                .PactUri("https://raw.githubusercontent.com/indiana-university/itpeople-app/develop/contracts/itpeople-app-itpeople-functions.json")
+                .PactUri("https://raw.githubusercontent.com/indiana-university/itpeople-app/feature/unit-contact-email/contracts/itpeople-app-itpeople-functions.json")
                 .Verify()
 
         [<Fact>]

--- a/functions.tests.integration/DatabaseTests.fs
+++ b/functions.tests.integration/DatabaseTests.fs
@@ -124,7 +124,7 @@ module DatabaseTests=
 
         [<Fact>]
         member __.``Create`` () = 
-            let expected = { Id=0; Name="Test"; Description="Desc"; Url="Url"; ParentId=Some(cityOfPawnee.Id); Parent=Some(cityOfPawnee) }
+            let expected = { Id=0; Name="Test"; Description="Desc"; Url="Url"; Email="email@domain.com"; ParentId=Some(cityOfPawnee.Id); Parent=Some(cityOfPawnee) }
 
             let actual = repo.Units.Create expected |> awaitAndUnpack
             let retrieved = repo.Units.Get actual.Id |> awaitAndUnpack
@@ -134,7 +134,7 @@ module DatabaseTests=
 
         [<Fact>]
         member __.``Update`` () = 
-            let expected = { Id=fourthFloor.Id; Name="Fourth Floor vNext"; Description="Re-org Fourth Flor"; Url="Url"; ParentId=Some(parksAndRec.Id); Parent=Some({parksAndRec with Parent=None}) }
+            let expected = { Id=fourthFloor.Id; Name="Fourth Floor vNext"; Description="Re-org Fourth Flor"; Url="Url"; Email="email@domain.com"; ParentId=Some(parksAndRec.Id); Parent=Some({parksAndRec with Parent=None}) }
 
             let actual = repo.Units.Update expected  |> awaitAndUnpack
             let retrieved = repo.Units.Get expected.Id |> awaitAndUnpack

--- a/functions.tests.unit/JsonTests.fs
+++ b/functions.tests.unit/JsonTests.fs
@@ -21,11 +21,13 @@ module JsonTests =
             ParentId= Some(1)
             Parent=None
             Url= "url"
+            Email="email@example.com"
           })
         let actual = tryDeserialize Status.BadRequest """{
           "id": 0,
           "name": "name",
           "url": "url",
+          "email": "email@example.com",
           "parentId": 1,
           "description": "description"
         }"""

--- a/functions/DatabaseRepository.fs
+++ b/functions/DatabaseRepository.fs
@@ -712,7 +712,7 @@ module DatabaseRepository =
         >>= fun depts -> ok { NetworkID=netid; DeptCodeList={Values=Seq.toArray depts } }
 
     let queryDepartmentLspsSql = """
-        SELECT p.name, p.netid, p.campus_phone, p.campus_email, MAX(um.role) in (3,4) as is_service_admin, COALESCE(u.email,p.campus_email) as notes
+        SELECT p.name, p.netid, p.campus_phone, p.campus_email, MAX(um.role) in (3,4) as is_service_admin, u.email as notes
         FROM people p
         JOIN unit_members um on um.person_id = p.id
         JOIN support_relationships sr on sr.unit_id = um.unit_id
@@ -730,8 +730,8 @@ module DatabaseRepository =
         FullName=p.Name 
         IsLSPAdmin=p.IsServiceAdmin // we override IsServiceAdmin in the query
         Email=p.CampusEmail 
-        PreferredEmail=p.Notes // we override Notes in the query 
-        GroupInternalEmail=p.Notes // we override Notes in the query
+        PreferredEmail= if isEmpty p.Notes then p.CampusEmail else p.Notes // we override Notes in the query 
+        GroupInternalEmail= ""
         Phone=p.CampusPhone }
 
     let queryDepartmentLsps connStr department = 

--- a/functions/DatabaseRepository.fs
+++ b/functions/DatabaseRepository.fs
@@ -712,14 +712,15 @@ module DatabaseRepository =
         >>= fun depts -> ok { NetworkID=netid; DeptCodeList={Values=Seq.toArray depts } }
 
     let queryDepartmentLspsSql = """
-        SELECT p.name, p.netid, p.campus_phone, p.campus_email, MAX(um.role) in (3,4) as is_service_admin
+        SELECT p.name, p.netid, p.campus_phone, p.campus_email, MAX(um.role) in (3,4) as is_service_admin, COALESCE(u.email,p.campus_email) as notes
         FROM people p
         JOIN unit_members um on um.person_id = p.id
         JOIN support_relationships sr on sr.unit_id = um.unit_id
         JOIN departments d on sr.department_id = d.id
+        JOIN units u on um.unit_id = u.id
         WHERE d.name ILIKE @Query 
             AND um.role <> 1
-        GROUP BY p.name, p.netid, p.campus_phone, p.campus_email"""
+        GROUP BY p.name, p.netid, p.campus_phone, p.campus_email, u.email"""
 
     let mapDepartmentLsps department (cn:Cn) = 
         cn.QueryAsync<Person>(queryDepartmentLspsSql, {Query=department})
@@ -727,10 +728,10 @@ module DatabaseRepository =
     let toLspContact (p:Person) =
       { NetworkID=p.NetId
         FullName=p.Name 
-        IsLSPAdmin=p.IsServiceAdmin 
+        IsLSPAdmin=p.IsServiceAdmin // we override IsServiceAdmin in the query
         Email=p.CampusEmail 
-        PreferredEmail=p.CampusEmail 
-        GroupInternalEmail=""
+        PreferredEmail=p.Notes // we override Notes in the query 
+        GroupInternalEmail=p.Notes // we override Notes in the query
         Phone=p.CampusPhone }
 
     let queryDepartmentLsps connStr department = 


### PR DESCRIPTION
This field will be used to facilitate unit contact. If this field is present on the unit, it be used at the 'preferred email' for departmental LSPs via the legacy web services.