### PR TITLE
Add tool automation safety check and logging

### DIFF
--- a/database/Migrations/18_CreateAutomationLogToolTable.fs
+++ b/database/Migrations/18_CreateAutomationLogToolTable.fs
@@ -1,0 +1,28 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
+namespace Migrations
+open SimpleMigrations
+
+[<Migration(18L, "Create automationlog_tools table")>]
+type CreateAutomationLogToolsTable() =
+  inherit Migration()
+  override __.Up() =
+    base.Execute("""
+    CREATE TABLE automationlog_tools (
+      id SERIAL NOT NULL,
+      ts timestamp without time zone default (now() at time zone 'utc'),
+      netid TEXT NOT NULL,
+      tool_name TEXT NOT NULL,
+      tool_path TEXT NOT NULL,
+      change_type TEXT NOT NULL,
+      unit_id TEXT NULL,
+      unit_name TEXT NULL,
+      PRIMARY KEY (id)
+    );
+    """)
+
+  override __.Down() =
+    base.Execute("""
+    DROP TABLE IF EXISTS automationlog_tools CASCADE;
+    """)

--- a/tasks/Functions.fs
+++ b/tasks/Functions.fs
@@ -7,7 +7,8 @@ module Types=
     open Core.Types
 
     type ADPath = string
-    type ADGroupMember = NetId * ADPath
+    type ToolName = string
+    type ADGroupMember = NetId * ADPath * ToolName
     
     type ToolPersonUpdate =
     | Add of ADGroupMember
@@ -26,6 +27,7 @@ module Types=
         GetAllTools: unit -> Async<Result<seq<Tool>, Error>>
         GetADGroupMembers: ADPath -> Async<Result<seq<NetId>, Error>>
         GetAllToolUsers: Tool -> Async<Result<seq<NetId>, Error>>
+        LogADGroupUpdate: ToolPersonUpdate -> Async<Result<ToolPersonUpdate, Error>>
         UpdateADGroup: ToolPersonUpdate -> Async<Result<ToolPersonUpdate, Error>>
         FetchAllHrPeople: unit -> Async<Result<seq<HrPerson>, Error>>
         UpdateHrPeople: seq<HrPerson> -> Async<Result<unit, Error>>
@@ -329,8 +331,8 @@ module DataRepository =
         let updateADGroup' (ldap:LdapConnection) =
             let (dn, modification) = 
                 match update with
-                | Add(netid, dn) -> dn, LdapModification(LdapModification.ADD, memberAttribute netid)
-                | Remove(netid, dn) -> dn, LdapModification(LdapModification.DELETE, memberAttribute netid)
+                | Add(netid, dn, _) -> dn, LdapModification(LdapModification.ADD, memberAttribute netid)
+                | Remove(netid, dn, _) -> dn, LdapModification(LdapModification.DELETE, memberAttribute netid)
             ldap.Modify(dn, modification)
             update
         try
@@ -384,7 +386,42 @@ module DataRepository =
                country = EXCLUDED.country;
                """
         execute connStr sql buildings
-        
+    
+    type ToolPersonUpdateRow = 
+      { ChangeType: string; 
+        NetId: string;
+        ToolName: string;
+        ToolPath: string; }
+
+    let logADGroupUpdate connStr toolPersonUpdate =
+        let sql = 
+            """with cte (unit_id, unit_name) as
+                ( 
+                	select u.id, u.name
+                	from units u
+                	join unit_members um on u.id = um.unit_id
+                	join unit_member_tools umt on um.id = umt.membership_id
+                	join tools t on t.id = umt.tool_id
+                	join people p on p.id = um.person_id
+                	where p.netid = @NetId
+                	and t.name = @ToolName
+                )
+                INSERT INTO automationlog_tools (change_type, netid, tool_name, tool_path, unit_id, unit_name)
+                SELECT 
+                    @ChangeType,
+                    @NetId,
+                    @ToolName,
+                    @ToolPath,
+                	string_agg(unit_id, '; '), 
+                	string_agg(unit_name, '; ')
+                FROM cte
+                """
+        let param = 
+            match toolPersonUpdate with
+            | Add(netid, path, name)    -> { NetId=netid; ToolPath=path; ToolName=name; ChangeType="add"; }
+            | Remove(netid, path, name) -> { NetId=netid; ToolPath=path; ToolName=name; ChangeType="remove"; }
+        execute connStr sql param
+        >>= fun () -> ok toolPersonUpdate
 
     let Repository psqlConnStr uaaUrl hrDataUrl adUser adPassword uaaUser uaaPassword buildingUrl buildingUser buildingPassword =
      { GetAllNetIds = fun () -> getAllNetIds psqlConnStr
@@ -393,6 +430,7 @@ module DataRepository =
        GetAllTools = fun () -> getAllTools psqlConnStr 
        GetADGroupMembers = getADGroupMembers adUser adPassword 
        GetAllToolUsers = getAllToolUsers psqlConnStr 
+       LogADGroupUpdate = logADGroupUpdate psqlConnStr
        UpdateADGroup = updateADGroup adUser adPassword
        FetchAllHrPeople = fetchAllHrPeople uaaUrl hrDataUrl uaaUser uaaPassword
        UpdateHrPeople = updateHrPeople psqlConnStr
@@ -405,14 +443,12 @@ module Functions=
     open Core.Types
     open Core.Json
 
-    open System
     open System.Net
     open System.Net.Http
     open Microsoft.Azure.WebJobs
     open Microsoft.Azure.WebJobs.Extensions.Http
     open Microsoft.Extensions.Logging
-    open SendGrid.Helpers.Mail
-
+    
     open Core.Util
     open Types
 
@@ -570,7 +606,7 @@ module Functions=
     // [<Disable>]
     [<FunctionName("ToolUpdateBatcher")>]
     let toolUpdateBatcher
-        ([<TimerTrigger("0 */15 * * * *")>] timer: TimerInfo,
+        ([<TimerTrigger("0 */5 * * * *")>] timer: TimerInfo,
          [<Queue("tool-update")>] queue: ICollector<string>,
          log: ILogger) =
 
@@ -616,11 +652,11 @@ module Functions=
             let addToAD = 
                 db 
                 |> Seq.except ad 
-                |> Seq.map (fun a -> Add(a, tool.ADPath))
+                |> Seq.map (fun a -> Add(a, tool.ADPath, tool.Name))
             let removeFromAD = 
                 ad 
                 |> Seq.except db 
-                |> Seq.map (fun a -> Remove(a, tool.ADPath))                
+                |> Seq.map (fun a -> Remove(a, tool.ADPath, tool.Name))                
 
             let countOfMembers = Seq.length ad
             let countOfRemoved = Seq.length removeFromAD
@@ -651,6 +687,7 @@ module Functions=
          
          let workflow =  
             tryDeserializeAsync<ToolPersonUpdate>
+            >=> data.LogADGroupUpdate
             >=> data.UpdateADGroup
             >=> tap logUpdate
          

--- a/tasks/Functions.fs
+++ b/tasks/Functions.fs
@@ -623,7 +623,7 @@ module Functions=
                 |> Seq.map (fun a -> Remove(a, tool.ADPath))                
 
             if ((Seq.length removeFromAD) = (Seq.length ad))
-            then error (Status.InternalServerError, sprintf "All tool grants for %s would be removed!" tool.Name)
+            then error (Status.InternalServerError, sprintf "All %d tool grants for %s would be removed!" (Seq.length removeFromAD) tool.Name)
             else ok (Seq.append addToAD removeFromAD)
                    
          let workflow =

--- a/tasks/Functions.fs
+++ b/tasks/Functions.fs
@@ -622,8 +622,10 @@ module Functions=
                 |> Seq.except db 
                 |> Seq.map (fun a -> Remove(a, tool.ADPath))                
 
-            if ((Seq.length removeFromAD) = (Seq.length ad))
-            then error (Status.InternalServerError, sprintf "All %d tool grants for %s would be removed!" (Seq.length removeFromAD) tool.Name)
+            let countOfMembers = Seq.length ad
+            let countOfRemoved = Seq.length removeFromAD
+            if (countOfRemoved <> 0 && countOfRemoved = countOfMembers)
+            then error (Status.InternalServerError, sprintf "All %d tool grants for %s would be removed!" countOfMembers tool.Name)
             else ok (Seq.append addToAD removeFromAD)
                    
          let workflow =

--- a/tasks/Functions.fs
+++ b/tasks/Functions.fs
@@ -659,8 +659,9 @@ module Functions=
                 |> Seq.map (fun a -> Remove(a, tool.ADPath, tool.Name))                
 
             let countOfMembers = Seq.length ad
+            let countOfAdded = Seq.length addToAD
             let countOfRemoved = Seq.length removeFromAD
-            if (countOfRemoved <> 0 && countOfRemoved = countOfMembers)
+            if (countOfAdded = 0 && countOfRemoved <> 0 && countOfRemoved = countOfMembers)
             then error (Status.InternalServerError, sprintf "All %d tool grants for %s would be removed!" countOfMembers tool.Name)
             else ok (Seq.append addToAD removeFromAD)
                    

--- a/tasks/Functions.fs
+++ b/tasks/Functions.fs
@@ -620,9 +620,11 @@ module Functions=
             let removeFromAD = 
                 ad 
                 |> Seq.except db 
-                |> Seq.map (fun a -> Remove(a, tool.ADPath))
-            let result = Seq.append addToAD removeFromAD 
-            result |> ok
+                |> Seq.map (fun a -> Remove(a, tool.ADPath))                
+
+            if ((Seq.length removeFromAD) = (Seq.length ad))
+            then error (Status.InternalServerError, sprintf "All tool grants for %s would be removed!" tool.Name)
+            else ok (Seq.append addToAD removeFromAD)
                    
          let workflow =
             tryDeserializeAsync<Tool>


### PR DESCRIPTION
* It's unlikely that we'd ever want to completely empty out a tool AD group. Add a safety check to prevent halt removals if the group would end up empty.
* Log tool grants/revocations to the `automationlog_tools` table. 